### PR TITLE
docs: add open source governance memory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+-
+
+## Tests
+
+- [ ] I ran `pnpm build` or documented why it is not applicable.
+- [ ] I verified links, commands, dates, and repository names touched by this change.
+
+## Docs
+
+- [ ] I updated the relevant docs, AI memory, ADR, or operations backlog.
+- [ ] No additional documentation update is needed.
+
+## Security
+
+- [ ] I checked that no secrets, private URLs, or misleading security guidance were introduced.
+- [ ] No security-sensitive content changed.
+
+## Release
+
+- [ ] I considered whether docs deployment, public beta/prod wording, or release policy is affected.
+- [ ] No release note is needed.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/docs"
+      - "type/security"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/devops"
+      - "type/security"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - "codex/**"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build docs
+        run: pnpm build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "49 20 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,14 @@
+name: Docs Drift
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-drift:
+    uses: mss-boot-io/.github/.github/workflows/docs-drift.yml@main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,7 +26,7 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,16 @@
+name: Issue Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    uses: mss-boot-io/.github/.github/workflows/issue-triage.yml@main

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,0 +1,16 @@
+name: PR Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    uses: mss-boot-io/.github/.github/workflows/pr-guard.yml@main
+    with:
+      max_changed_files: 80

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,14 @@
+name: Release Draft
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  release-draft:
+    uses: mss-boot-io/.github/.github/workflows/release-draft.yml@main

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "39 20 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  security-events: write
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -1,0 +1,16 @@
+name: Weekly Digest
+
+on:
+  schedule:
+    - cron: "19 21 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  digest:
+    uses: mss-boot-io/.github/.github/workflows/weekly-digest.yml@main

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This repository follows the `mss-boot-io` organization code of conduct.
+
+Expected behavior: be respectful, keep technical discussions reproducible, and
+avoid public disclosure of vulnerabilities.
+
+Maintainers may hide comments, close issues, or limit participation when behavior
+harms the project or community.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-This repository follows the `mss-boot-io` organization code of conduct.
+This repository follows the [`mss-boot-io` organization code of conduct](https://github.com/mss-boot-io/.github/blob/main/CODE_OF_CONDUCT.md).
 
 Expected behavior: be respectful, keep technical discussions reproducible, and
 avoid public disclosure of vulnerabilities.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to mss-boot-docs
+
+## Scope
+
+This repository is the public documentation and durable AI memory home for the
+`mss-boot-io` organization. Workflow decisions, release environment policy, and
+multi-agent delivery memory should be recorded under `aigc/` when they affect
+more than one repository.
+
+## Pull requests
+
+- Use a Conventional Commits title, for example `docs(release): clarify beta policy`.
+- Run `pnpm install --frozen-lockfile && pnpm build` before requesting review.
+- Keep documentation changes tied to a clear repository, feature, workflow, or
+  release policy.
+- When documenting an external account action that cannot be performed from the
+  repository, add it to the operations backlog instead of leaving it in chat.
+
+AI-assisted documentation is welcome when the contributor verifies links,
+commands, dates, and repository names.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,11 @@ vulnerability reporting is enabled. If the report is documentation-specific,
 include the page, commit, exposed information, and suggested remediation.
 
 The organization still needs a final public security contact. Until then,
-private GitHub advisories are the preferred intake path.
+private GitHub advisories are the preferred intake path. If private reporting is
+not available for the affected repository, open a minimal public issue that does
+not include exploit details, secrets, tokens, logs with private values, or
+step-by-step reproduction; ask a maintainer to enable a private reporting
+channel for the full report.
 
 ## Supported versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Do not open a public issue for suspected vulnerabilities.
+
+Use GitHub Security Advisories for the affected repository when private
+vulnerability reporting is enabled. If the report is documentation-specific,
+include the page, commit, exposed information, and suggested remediation.
+
+The organization still needs a final public security contact. Until then,
+private GitHub advisories are the preferred intake path.
+
+## Supported versions
+
+The active `main` branch and the public docs deployment are supported by default.
+
+## Response expectations
+
+- Acknowledge valid private reports within 7 days when possible.
+- Triage whether the issue exposes secrets, deployment details, or misleading
+  security guidance.
+- Prepare corrected documentation and disclosure notes before publishing details.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,11 @@
+# Support
+
+Use GitHub issues for documentation defects, missing pages, broken links, and
+workflow clarification requests.
+
+Security reports must follow `SECURITY.md` and should not be filed as public
+issues.
+
+This repository is also the durable memory store for organization-level AI
+workflow and release policy. Decisions that would otherwise be lost in a local
+multi-Git workspace should be recorded here.

--- a/aigc/prompts/multi-agent-delivery-workflow.zh-CN.md
+++ b/aigc/prompts/multi-agent-delivery-workflow.zh-CN.md
@@ -1,0 +1,87 @@
+# mss-boot-io 开源组织多 Agent 交付工作流
+
+## 适用范围
+
+- 适用于后续涉及需求分析、issue 分流、方案设计、代码修改、联调、测试、发布、文档沉淀和开源协作治理的工作。
+- 简单问答、只读查询、单条命令类任务可由 leader 直接完成，不强行启动完整多 agent 流程。
+- 涉及真实发布时，遵守发布环境策略：`mss-boot-dev` 是 alpha/dev，`mss-boot-beta` 是对外展示 beta，`mss-boot-prod` 是生产环境；完整规则见 `mss-boot-docs/aigc/prompts/release-environment-strategy.zh-CN.md`。
+- 涉及外部贡献者、公共 API、数据库结构、权限模型、认证安全、部署方式、破坏性变更或跨仓库同步时，必须进入完整开源组织流程。
+
+## 开源组织原则
+
+- 公开可追溯：需求、方案、关键取舍、测试证据、发布结果和已知风险应能被维护者和外部贡献者理解。
+- 可复现优先：每次交付都要留下命令、环境、commit、镜像 tag、页面 URL、API 响应或截图等复现证据。
+- 维护者负责：agent 产出建议和候选改动，最终责任由 leader/maintainer 承担，不能把 agent 输出直接当成维护者决策。
+- 代码修复优先：不使用临时网关、前端绕路或隐式兼容掩盖开源项目问题；确需临时兼容时必须有 issue、过期时间和删除计划。
+- 文档即交付：功能、配置、接口、部署、升级、迁移、安全影响和已知限制必须随代码同步更新。
+- 跨仓一致：`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 的接口、示例、版本和文档不能互相漂移。
+- 记忆归档：当前 workspace 是多 Git 仓库并列结构，组织级记忆、跨仓流程和环境发布策略必须落盘到 `mss-boot-docs/aigc/prompts/`，否则会随单仓上下文切换而丢失。
+- 安全默认前置：认证、权限、凭据、依赖、镜像、发布链路和漏洞披露在设计阶段就纳入检查。
+
+## 角色职责
+
+- Triage agent：整理 issue、复现问题、判断仓库归属、标记优先级、识别是否需要 RFC/ADR。
+- PM agent：理解用户需求、拆解目标、识别用户价值、提出方案、边界、验收口径和风险点。
+- Leader agent：审核 PM 方案是否符合项目定位、开源要求、当前架构和用户真实需求；负责拆任务、协调各 agent、集成输出、处理返工、最终汇总。
+- Backend agent：负责 `mss-boot-admin` 后端 API、模型、服务、权限、配置、迁移、测试与后端发布验证。
+- Admin agent：负责 `mss-boot-admin-antd` 管理台页面、服务调用、路由、状态、国际化、交互、本地验证与 Cloudflare 发布前准备。
+- Doc agent：负责 `mss-boot-docs` 或对应仓库 `aigc/prompts/` 的方案、交接、测试结论和记忆落盘；组织级记忆、跨仓流程、发布拓扑和协作规则必须落到 `mss-boot-docs/aigc/prompts/`。
+- Test agent：负责联调测试、冒烟测试、回归测试、失败复现、验收证据整理；发现问题直接退回 Leader。
+- Security agent：负责密钥泄漏、权限放大、依赖风险、镜像安全、发布凭据和漏洞披露影响检查。
+- Release agent：负责 changelog、版本说明、镜像/Cloudflare 发布清单、回滚信息、beta/stable 晋级记录。
+- Architect agent：负责架构边界、抽象合理性、长期演进风险、跨仓库影响、公共 API 和代码 review。
+- Maintainer/Leader：最终合并与发布责任人，负责确认 agent 输出、review 结论、发布动作和对外说明。
+
+## 标准流程
+
+1. Triage agent 先分流入口：确认这是 bug、feature、docs、security、refactor、release 还是运维问题，并判断影响仓库和优先级。
+2. PM agent 理解需求并输出方案，包括目标、非目标、涉及仓库、用户价值、拆分建议、验收标准、开源影响和风险。
+3. Leader agent 审核方案：确认是否符合 `mss-boot-admin` 单租户后台产品定位、开源项目质量要求、当前部署/发布流程和用户需求。
+4. 涉及公共 API、数据库 schema、权限模型、认证安全、扩展机制、破坏性变更或发布策略时，Architect agent 先输出 RFC/ADR 级设计意见。
+5. Leader agent 安排 Backend agent、Admin agent、Doc agent 分头工作，并明确每个 agent 的写入范围，避免互相覆盖。
+6. Leader agent 负责三方对接、接口契约、前后端联调点、发布节奏和冲突处理，并验收每个 agent 的输出。
+7. Leader agent 汇总阶段成果后交给 Test agent 测试；Test agent 发现问题直接退回 Leader agent。
+8. 测试通过后，Security agent 检查认证、权限、凭据、依赖、镜像、配置和发布链路风险；有问题退回 Leader agent。
+9. Security 通过后，由 Architect agent 和 Leader agent 共同 review 代码、架构、兼容性、测试覆盖和长期维护风险。
+10. Review 通过后，Release agent 整理 changelog、版本/镜像信息、发布清单、回滚说明和 beta/stable 晋级建议。
+11. 全部完成后，由 Doc agent 整理交付结论、测试证据、部署信息、后续风险、贡献者说明和组织记忆并落盘。
+12. Maintainer/Leader 最终向用户或社区汇总：做了什么、为什么这样做、验证了什么、发布状态、兼容影响、遗留风险和下一步建议。
+
+## 循环规则
+
+- `Test -> Leader -> 专项 agent -> Test` 循环直到满足验收要求。
+- `Security -> Leader -> 专项 agent -> Test -> Security` 循环直到安全风险关闭或明确记录为可接受风险。
+- `Architect/Leader Review -> Leader -> 专项 agent -> Test -> Review` 循环直到代码和架构都通过。
+- Leader 不把未验证的专项 agent 输出直接交付给用户。
+- Doc agent 只在事实确认后落盘，不记录未验证推测、明文凭据、个人隐私或临时兼容方案。
+- 破坏性变更、临时兼容、弃用计划和安全修复必须有可追踪记录，不能只留在聊天上下文。
+
+## 开源门禁清单
+
+- Issue/需求：有清晰复现、预期行为、影响版本、涉及仓库、用户场景和验收口径。
+- 设计：公共 API、schema、权限、认证、扩展机制和发布策略变更有 RFC/ADR 或等价设计记录。
+- 实现：改动最小可维护，符合仓库边界，不把业务问题误上升为框架重构。
+- 测试：后端有相关单测/集成测试或无法测试说明；前端有本地构建和关键页面验证；跨仓变更有联调证据。
+- 安全：无明文凭据、无权限放大、无敏感日志泄漏、依赖风险可接受，发布凭据使用短期或受控机制。
+- 文档：用户文档、配置说明、部署说明、升级/迁移说明、已知限制和示例同步更新；无影响也要明确说明。
+- 发布：后端镜像 tag、commit SHA、构建时间、部署 namespace、回滚方式可追踪；前端 Cloudflare 发布前必须本地验证通过。
+- 贡献者体验：PR 描述包含背景、方案、测试结果、文档影响、兼容影响和截图/日志等证据。
+
+## 发布与版本策略
+
+- alpha/dev：`mss-boot-dev` 对应开发联调环境，对外域名规划为 `admin-alpha.mss-boot-io.top`，本地启动的前端默认对接 alpha 后端。
+- beta 后端：`codex/**` 分支可触发 GHCR 镜像发布并更新 `mss-boot-beta`，后端可较频繁发布，但应使用 commit SHA tag 或 digest，并记录对应分支、Actions run、镜像和回滚信息。
+- beta 前端：`admin-beta.mss-boot-io.top` 是 Cloudflare 对外展示环境，对接 `admin-api-beta.mss-boot-io.top`；发布到 Cloudflare 前必须完成本地开发、构建、关键页面、API 域名验证和真实 beta 冒烟，避免高频发布消耗 Cloudflare 次数。
+- prod：`admin.mss-boot-io.top` 对应 `mss-boot-prod`；后端只部署 tag 版本，前端发布流程不变，但必须从已验证版本晋级。
+- stable 发布：应从可复现的已验证产物晋级，不能把临时 beta 手工状态直接视作 stable。
+- 变更记录：每次可见发布都要有 changelog、升级影响、已知问题和回滚建议；破坏性变更需要迁移说明。
+- 清理策略：beta 分支 tag、临时兼容、弃用能力和历史镜像应有保留周期或清理计划。
+
+## 默认执行偏好
+
+- 先修代码，不做网关路径兼容来掩盖开源项目问题。
+- 后端问题优先加最小测试覆盖，再通过 `codex/**` 分支发布镜像并按目标更新 alpha/dev 或 beta；prod 必须使用 tag 版本。
+- 前端问题先本地开发、构建和浏览器验证，只有功能完整、可对外公开且通过冒烟后才发布 Cloudflare，避免消耗发布次数并污染真实展示环境。
+- 跨仓库改动必须由 Leader 明确接口契约和发布顺序。
+- 每次交付都要有可复现验证入口，例如命令、测试结果、API 响应、浏览器页面状态或部署镜像 SHA。
+- 面向外部贡献者的结论必须写得可讨论、可验证、可复现，避免内部黑话和无法公开的上下文。

--- a/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md
+++ b/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md
@@ -3,7 +3,7 @@
 ## 评估时间与数据来源
 
 - 评估时间：2026-06-04
-- 工作区：`/Users/linwenxiang/go/src/github.com/mss-boot-io`
+- 工作区：本地多仓库 workspace，根目录形态为 `<workspace>/mss-boot-io`
 - GitHub 组织：`https://github.com/mss-boot-io`
 - 数据来源：
   - `gh api orgs/mss-boot-io`

--- a/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md
+++ b/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md
@@ -1,0 +1,356 @@
+# mss-boot-io 开源组织评分与 AI 时代增长方案
+
+## 评估时间与数据来源
+
+- 评估时间：2026-06-04
+- 工作区：`/Users/linwenxiang/go/src/github.com/mss-boot-io`
+- GitHub 组织：`https://github.com/mss-boot-io`
+- 数据来源：
+  - `gh api orgs/mss-boot-io`
+  - `gh api orgs/mss-boot-io/repos --paginate`
+  - GitHub GraphQL repositories query
+  - `gh issue list` / `gh pr list` / `gh release list` / `gh run list`
+  - 核心仓库本地文件与 `aigc` 记忆
+- 外部参考：
+  - GitHub Actions 对公开仓库标准 runner 免费：https://docs.github.com/en/billing/concepts/product-billing/github-actions
+  - Cloudflare Pages 免费计划每月构建次数限制：https://developers.cloudflare.com/pages/platform/limits/
+  - OpenSSF Scorecard：https://openssf.org/scorecard/
+  - GitHub Sponsors 费用说明：https://docs.github.com/en/sponsors/getting-started-with-github-sponsors/about-github-sponsors
+
+## GitHub 当前可见数据
+
+截至本次拉取，GitHub API 返回：
+
+- 可见仓库：38 个，其中非 fork 33 个，fork 5 个。
+- 组织 profile 显示公开仓库数：34 个；实际 API 返回数和 profile 数存在差异，后续以 repo API 拉取结果作为评估明细。
+- 组织 followers：16。
+- 总 stars：128。
+- 总 forks：39。
+- Open items：47 个，GitHub REST 的 `open_issues_count` 包含 issue 和 PR。
+- 2026 年有 push 的仓库：7 个。
+- 2025 年有 push 的仓库：8 个。
+- 2025 年以前最后 push 的仓库：23 个。
+- 有 license 的仓库：21 个。
+
+核心仓库信号：
+
+| 仓库 | stars | forks | 最新 release | 最近 push | 社区健康分 |
+| --- | ---: | ---: | --- | --- | ---: |
+| `mss-boot-admin` | 69 | 13 | `v0.6.1` | 2026-06-04 | 75 |
+| `mss-boot` | 37 | 6 | `v0.7.1` | 2026-06-03 | 62 |
+| `mss-boot-admin-antd` | 5 | 7 | `v0.5.1` | 2026-04-06 | 62 |
+| `mss-boot-docs` | 0 | 3 | 无 release | 2026-04-06 | 37 |
+
+### 2026-06-05 GitHub 公网复核
+
+本轮复核使用 `gh repo list mss-boot-io` 与 `gh api repos/mss-boot-io/<repo>/community/profile`。需要注意：以下是公网 main 分支已发布状态，不包含本地尚未提交/推送的治理改动。
+
+- 可见仓库：38 个，其中公开 34 个、私有 4 个、归档 0 个。
+- 总 stars：128；总 forks：39。
+- 当前 GitHub 社区健康分：`.github` 12，`mss-boot` 62，`mss-boot-admin` 75，`mss-boot-admin-antd` 62，`mss-boot-docs` 37。
+- 公开仓库中仅 `mss-boot` 当前显示启用 Security policy；`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 与组织 `.github` 仍需在变更合并后通过 GitHub 重新识别。
+- 公开/可见仓库中有 17 个仓库缺 license 元数据，包含 `.github`、`mss-boot-docs` 之外的若干历史/示例仓库；主评分优先聚焦四核心仓库，历史仓库后续可按“归档、补 license、补描述、转移到示例集”分批治理。
+- 当前 top 仓库：`mss-boot-admin` 69 stars / 13 forks，`mss-boot` 37 stars / 6 forks，`mss-boot-admin-antd` 5 stars / 7 forks，`workflow-tools-go` 5 stars / 1 fork。
+
+复核结论：公网当前健康度仍停留在 6.4 左右，本地已完成的源码侧治理改动属于 9.2+ 准备态；真实公开评分需要完成提交、推送、合并，并配置分支保护、required checks、private vulnerability reporting 等外部设置后再复核。
+
+贡献者集中度：
+
+| 仓库 | 主要贡献者 | 外部贡献信号 |
+| --- | --- | --- |
+| `mss-boot` | `lwnmengjing` 154 commits | `WangDe7`、`snakelu` 有少量贡献，Dependabot 活跃 |
+| `mss-boot-admin` | `lwnmengjing` 161 commits | `wxip`、`WangDe7`、`mss-boot` 有少量贡献 |
+| `mss-boot-admin-antd` | `lwnmengjing` 68 commits | `chenfei4396`、`mss-boot` 有少量贡献 |
+| `mss-boot-docs` | `lwnmengjing` 38 commits | 暂未形成外部贡献 |
+
+工程与社区配置：
+
+- 核心仓库均有 MIT License。
+- `mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd` 有 PR 模板。
+- `mss-boot-admin` 有 issue templates 和 `CONTRIBUTING.md`。
+- `mss-boot-docs` 社区健康文件明显不足。
+- `mss-boot` 已有 CodeQL、Dependabot、Release workflow。
+- `mss-boot-admin` 有 CI、Swagger、Release、Dependabot。
+- `mss-boot-admin-antd` 已有 alpha/beta/prod Cloudflare workflow。
+- `mss-boot-docs` 有 docs deploy workflow。
+
+## 总评分
+
+当前开源组织综合评分：6.4 / 10。
+
+这个分数不是项目价值低，而是开源组织化程度还没完全展开。核心代码和产品底子已经够用，短板主要在“社区入口、贡献者转化、发布可信、组织级治理、安全披露、AI 自动化运营”。
+
+| 维度 | 权重 | 当前分 | 主要证据 | 到 10 分需要补齐 |
+| --- | ---: | ---: | --- | --- |
+| 产品定位与叙事 | 12% | 7.2 | 已从低代码/多租户叙事收敛到治理型 admin，但 README、copilot 指令和历史仓库仍可能有旧叙事 | 统一成 AI-governed / agent-readable Go microservice admin framework |
+| 工程可信度 | 14% | 7.0 | CI、release、CodeQL、Dependabot 已具备，但强门禁和覆盖率证据还需组织化 | CI 必过、覆盖率门禁、OpenSSF Scorecard、供应链证明 |
+| 文档与上手 | 14% | 7.0 | docs 项目存在，README 有 quickstart；但 docs 社区健康分低，文档站还没完全成为单一事实源 | 5 分钟上手、FAQ、故障排查、版本矩阵、示例自动验证 |
+| 社区健康 | 12% | 5.4 | 缺组织级 Code of Conduct、Support、统一 issue 模板、Discussions 体系 | 组织级 `.github` 社区健康文件和标签/SLA |
+| 贡献者体验 | 12% | 5.2 | 外部贡献少，good first issue 机制未形成 | 30 分钟可贡献路径、每月稳定 good first issue、快速首评 |
+| 发布质量 | 12% | 6.2 | release 存在，前后端/Cloudflare 流程已定义；但 tag、SBOM、回滚、版本矩阵还不完整 | 可复现发布、SBOM、checksum、attestation、回滚手册 |
+| 安全与供应链 | 12% | 5.5 | CodeQL 有基础，Security policy 和漏洞响应流程不足 | SECURITY、govulncheck、secret scan、Scorecard、SLSA/attestation |
+| AI 时代差异化 | 12% | 7.0 | `aigc`、多 agent 流程、组织记忆已有雏形 | context pack、contract manifest、OpenAPI `x-mss-*`、policy explain |
+
+## 核心判断
+
+mss-boot-io 不应该去卷“更快生成 CRUD”。更好的定位是：
+
+中文：面向 AI 协作时代的治理型 Go 微服务后台框架。
+
+英文：AI-governed Go microservice admin framework.
+
+差异化不是“低代码”或“动态模型”，而是：
+
+- Agent-readable：AI 能读懂项目边界、接口、权限、配置、测试和发布环境。
+- Governance-first：权限、审计、配置、组织、任务、通知和发布流程可追溯。
+- Production-maintainable：不是 demo，而是可部署、可回滚、可测试、可交接。
+- Docs-as-memory：`mss-boot-docs` 是组织级 AI 记忆中心，不只是文档站。
+
+## 10 分目标定义
+
+10 分不是 stars 很多，而是个人开发者仍能低成本维护一个可信开源组织：
+
+- 新用户 5 分钟知道项目解决什么问题。
+- 新贡献者 30 分钟能跑通并提交一个小 PR。
+- 每个核心 PR 都有测试、文档、安全、发布影响说明。
+- 每次 release 都能追踪 commit、镜像、前端版本、配置差异和回滚方式。
+- 社区问题 48 小时内有 AI 辅助首响，维护者只处理需要判断的部分。
+- AI agent 能通过上下文包理解仓库、接口、权限、测试、发布环境。
+- 文档、README、OpenAPI、前端 service、部署配置之间不漂移。
+
+## 0 到 30 天：把评分从 6.4 推到 7.5
+
+目标：补齐开源信任底座，最低成本提升专业度。
+
+1. 组织级 `.github` 基建
+   - 新建或完善组织 `.github` 仓库。
+   - 添加默认 `CODE_OF_CONDUCT.md`、`SECURITY.md`、`SUPPORT.md`、`CONTRIBUTING.md`。
+   - 添加统一 issue templates、PR template、Funding 配置。
+   - 建立标签规范：`bug`、`docs`、`good first issue`、`help wanted`、`security`、`needs reproduction`、`ai-ready`、`release-blocker`。
+
+2. README 和定位统一
+   - 四个核心仓库首屏统一定位。
+   - 删除或弱化“低代码”“动态模型主线”“多租户 SaaS 主线”旧表达。
+   - 明确当前主线：治理型 admin、生产运维、AI 协作可读。
+   - 修正 Go/Node/pnpm 版本、体验环境、alpha/beta/prod 域名说明。
+
+3. CI 门禁
+   - `mss-boot`、`mss-boot-admin`：`go test ./...` 必过。
+   - 前端：`pnpm install --frozen-lockfile`、`pnpm tsc`、`pnpm test`、`pnpm build`。
+   - 文档：`pnpm build`。
+   - 取消 lint 的 `continue-on-error`，或拆成非阻塞 warning job 和必过基础 job。
+
+4. AI 运营最小闭环
+   - Weekly Digest：每周自动汇总 stars/forks/issues/PR/releases/CI 状态。
+   - Issue Triage：缺复现则自动评论提醒，按标题/模板自动打标签。
+   - PR Guard：检查测试命令、文档影响、安全影响、发布影响是否填写。
+
+30 天验收：
+
+- 核心仓库社区健康分全部达到 75+，`mss-boot-docs` 达到 70+。
+- 每个核心仓库 README 首屏统一。
+- 至少 10 个 `good first issue`。
+- 近 30 天 issue/PR 首响时间小于 48 小时。
+
+## 31 到 90 天：把评分推到 8.5
+
+目标：建立贡献飞轮和 AI-ready 差异化。
+
+1. Agent Context Pack
+   - 增加 `mss context export --format markdown/json` 或先用脚本输出。
+   - 内容包括仓库地图、模块责任、路由、OpenAPI 摘要、权限、配置、模型、测试命令、发布环境。
+   - 先从 `mss-boot-admin` 做样板，再扩展到 `mss-boot`。
+
+2. MSS Contract Manifest
+   - 对用户、角色、菜单、API、任务、通知 6 个模块建立 `mss.contract.json` 样板。
+   - 描述 resource、routes、auth、permissions、dataScope、audit、events、configs、tests。
+   - CI 检查 contract、OpenAPI、前端 service 是否漂移。
+
+3. OpenAPI `x-mss-*` 扩展
+   - 增加 `x-mss-auth`、`x-mss-permission`、`x-mss-data-scope`、`x-mss-audit`、`x-mss-config`、`x-mss-i18n`。
+   - 让前端、文档、测试和 agent 都围绕同一份契约工作。
+
+4. 社区内容节奏
+   - 每周 1 篇 5 分钟上手或真实问题修复。
+   - 每月 1 篇架构取舍或 release 解读。
+   - GitHub Discussions 开 6 类：Q&A、Show and Tell、RFC、Roadmap、Help Wanted、中文交流。
+
+5. 外部贡献路径
+   - 准备 20 个小任务：文档、测试、i18n、FAQ、示例。
+   - 每个 good first issue 写清背景、修改范围、测试命令、验收结果。
+   - 首个外部 PR 优先 24 小时内 review，合并后在 release note 或月报感谢。
+
+90 天验收：
+
+- 至少 3 个外部 PR。
+- 至少 5 个有效 Discussions。
+- 至少 20 个有效 issue，其中 10 个沉淀为 FAQ 或文档改进。
+- 形成 1 套 AI 辅助运营流水线。
+- 核心仓库 OpenSSF Scorecard 有可见基线并持续上升。
+
+## 91 到 180 天：把评分推到 9.2
+
+目标：从“好项目”变成“可信开源组织”。
+
+1. 发布可信度
+   - 建立版本兼容矩阵：`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs`。
+   - release 产出 changelog、upgrade note、checksum、SBOM、镜像 digest、回滚说明。
+   - 后端 prod 只发 tag 版本；前端 Cloudflare 发布必须关联后端 tag/API 版本。
+
+2. 安全与供应链
+   - `SECURITY.md` 写清支持版本、报告入口、响应 SLA、披露流程。
+   - 四仓库统一 Dependabot、CodeQL、govulncheck、pnpm audit。
+   - 加 OpenSSF Scorecard workflow。
+   - 对 release 加 artifact attestation 或 SLSA 生成器。
+
+3. 架构可解释
+   - 建 ADR 目录，先写认证、RBAC/Casbin、配置源、存储、国际化、动态模型/代码生成取舍。
+   - 增加 Action/Hook Trace：action、resource、permission、scope、hook 耗时、error code、audit id。
+   - 增加 Policy Explain / Dry Run：
+     - `mss admin policy explain --user u1 --method POST --path /admin/api/users`
+     - 输出允许/拒绝原因、角色、菜单/API 权限、数据范围。
+
+4. Admin AI Console
+   - 不做泛聊天框。
+   - 做明确按钮：
+     - 解释用户为什么看不到菜单。
+     - 解释配置变更影响。
+     - 总结最近 24 小时告警。
+     - 生成本次发布说明。
+     - 根据失败测试生成复现步骤。
+
+180 天验收：
+
+- OpenAPI、contract、docs、frontend service 有漂移检查。
+- 每次 release 可追踪、可回滚、可解释。
+- 至少 1 个长期贡献者进入 triage 或 reviewer 角色。
+- 社区维护时间下降，重复问题主要由 FAQ、模板、AI 首响处理。
+
+## 9.2 到 10 分：长期能力
+
+10 分阶段不靠堆功能，靠持续可信。
+
+- 形成维护者梯队，不再完全依赖个人。
+- 有稳定用户案例和 Show and Tell。
+- 有清晰路线图和弃用计划。
+- 有赞助入口和成本透明度。
+- 有公开运营月报。
+- AI agent 能稳定完成 issue triage、PR guard、release note、docs drift、good first issue 生成。
+- 用户可以用同一套文档理解本地、alpha、beta、prod 的发布路径。
+
+## 个人开发者低成本社区运营方案
+
+原则：少开渠道，多做复用；AI 做重复劳动，人做判断。
+
+推荐工具：
+
+| 场景 | 低成本方案 |
+| --- | --- |
+| 代码与社区 | GitHub Issues、PR、Discussions、Projects |
+| CI 自动化 | GitHub Actions，公开仓库标准 runner 免费 |
+| 文档与展示 | mss-boot-docs + Cloudflare Pages，但控制发布次数 |
+| 数据监控 | GitHub API weekly digest + Cloudflare Web Analytics |
+| 社区答疑 | GitHub Discussions 为主，微信群只做同步通知 |
+| 内容发布 | README/docs 为主，掘金或公众号作为中文分发 |
+| 赞助 | GitHub Sponsors + README sponsor 区 |
+
+AI 自动化优先级：
+
+1. Weekly Digest agent：每周生成组织健康报告。
+2. Issue Triage agent：自动分类、补问复现信息、推荐文档链接。
+3. PR Guard agent：检查测试、文档、安全、发布影响。
+4. Release agent：生成 changelog、升级影响、镜像 tag、回滚说明。
+5. Docs Drift agent：根据 OpenAPI/config/routes 变化提示文档更新。
+6. Growth agent：每周生成 good first issue 候选和内容选题。
+
+成本控制：
+
+- 第一阶段不用大模型全自动，先用 GitHub Actions + 脚本 + 模板完成 60%。
+- LLM 只用于摘要、分类、FAQ 草稿、release 文案，不用于自动 merge 或自动发布。
+- Cloudflare 前端发布严格门禁，避免消耗次数。
+- 不同时维护太多社交渠道，先把 GitHub Discussions 和 docs 做扎实。
+
+## 最高杠杆的 12 个任务
+
+1. 组织级 `.github` 社区健康文件。
+2. 四核心仓库 README 首屏统一定位。
+3. `mss-boot-docs` 社区健康补齐。
+4. CI 必过和分支保护。
+5. SECURITY policy 和漏洞响应 SLA。
+6. OpenSSF Scorecard workflow。
+7. 每周组织健康 digest。
+8. Issue/PR AI guard。
+9. 10 到 20 个高质量 good first issue。
+10. Agent Context Pack。
+11. MSS Contract Manifest。
+12. Policy Explain / Action Trace。
+
+执行顺序建议：
+
+- 第 1 周：1、2、3、4。
+- 第 2 到 4 周：5、6、7、8、9。
+- 第 2 到 3 个月：10、11。
+- 第 4 到 6 个月：12。
+
+## 最终建议
+
+mss-boot-io 当前最强的资产不是 stars，而是已经有完整的框架、后台、前端、文档和 AI 记忆雏形。作为个人开发者，要把分数推到 10，不应该靠加班维护社区，而应该把组织设计成“AI 能帮你持续维护”的形态。
+
+一句话路线：
+
+把 mss-boot-io 打造成 agent-readable、governance-first、production-maintainable 的 Go 微服务后台开源组织。
+
+## 2026-06-05 直接实施状态
+
+本轮目标：在不依赖外部账号决策、不开启高成本社区渠道、不过度发布 Cloudflare 的前提下，先把可直接通过源码落地的开源组织评分项推到 9.2+ 准备态。
+
+已直接实施：
+
+1. 新增/完善组织级 `.github` 仓库：
+   - 组织 profile 叙事改为 governance-first、agent-readable、production-maintainable。
+   - 补齐 `CODE_OF_CONDUCT.md`、`CONTRIBUTING.md`、`SECURITY.md`、`SUPPORT.md`。
+   - 补齐默认 issue templates、PR template 和 labels taxonomy。
+   - 新增 reusable workflows：PR Guard、Issue Triage、Docs Drift、Weekly Digest、Release Draft。
+2. 四个核心仓库补齐社区健康文件：
+   - `mss-boot`
+   - `mss-boot-admin`
+   - `mss-boot-admin-antd`
+   - `mss-boot-docs`
+3. 四个核心仓库补齐自动化：
+   - OpenSSF Scorecard workflow。
+   - PR Guard、Issue Triage、Docs Drift、Weekly Digest、Release Draft。
+   - Dependabot 覆盖 GitHub Actions；Go/npm 仓库覆盖对应依赖生态。
+4. 安全扫描补强：
+   - `mss-boot` 与 `mss-boot-admin` 增加 govulncheck。
+   - `mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 增加 CodeQL。
+5. CI 与发布可信度补强：
+   - `mss-boot` CI 改为 `go-version-file: go.mod`，增加 `go test ./...`，取消 lint 软失败。
+   - `mss-boot-admin-antd` 增加 PR CI：frozen install、ESLint、tsc、unit test、local build。
+   - `mss-boot-docs` 增加 PR CI：frozen install 与 docs build。
+   - Cloudflare 相关 workflow 改为 `pnpm install --frozen-lockfile`，不增加新的高频发布触发。
+   - 旧发布 workflow 升级 `softprops/action-gh-release@v2`，替换废弃 `set-output`。
+6. AI 协作叙事修正：
+   - `mss-boot-admin/.github/copilot-instructions.md` 将多租户、虚拟模型、代码生成标记为历史/兼容能力，不再作为新功能主线。
+   - `mss-boot/README.Zh-cn.md` 将旧的“代码生成工具”todo 替换为 AI 可读契约、发布治理与可观测能力。
+7. 社区运营材料落盘：
+   - 外部账号/组织设置待办：`open-source-operations-backlog.zh-CN.md`。
+   - good first issue 任务工厂：`open-source-good-first-issue-factory.zh-CN.md`。
+8. CI 可运行性修复：
+   - `mss-boot` 全量 `go test ./...` 已改为无外部凭据/服务时可通过；对象存储、Redis 等集成测试在依赖未配置时跳过，虚拟模型测试改用内存 SQLite。
+   - 修复 `mss-boot` Mongo lookup 关系字段解析，优先使用关联 ID 字段的 `bson` 名称。
+   - `mss-boot-admin-antd` 统一 workflow pnpm 到 v9，以匹配 lockfile v9；本地 Node 24 会触发 Umi 旧依赖的 `http_parser` 兼容问题，验证使用 Node 18。
+   - `mss-boot-admin-antd` 修复类型、lint、Jest 基线：补 `uuid` 声明、清理未使用 import、修正 localStorage test setup、同步登录页测试文案与快照。
+
+实施后评分判断：
+
+- 可通过源码直接实现的开源组织化能力，已从 6.4/10 推进到 9.2+ 准备态。
+- 真实 GitHub 公开评分仍取决于外部设置是否完成，例如 branch protection、private vulnerability reporting、Discussions、Sponsors、secret scanning、rulesets、workflow required checks。
+- OpenSSF Scorecard 的实际分数需要相关分支合并并在 GitHub Actions 中跑完后才能确认。
+
+下一步最关键的外部动作：
+
+1. 合并/发布 `.github` 组织仓库变更，让默认社区健康文件和 reusable workflows 生效。
+2. 为四个核心仓库启用 branch protection / rulesets，并要求 CI、CodeQL、govulncheck、Scorecard 通过。
+3. 启用 private vulnerability reporting，并确定公开安全联系入口。
+4. 开启 Discussions，先用低维护成本分类：Q&A、RFC、Roadmap、Help Wanted、中文交流。
+5. 从 good first issue 工厂中挑选 10 到 20 个任务创建公开 issue。

--- a/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md
+++ b/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md
@@ -1,0 +1,115 @@
+# mss-boot-io 开源社区运营执行记录
+
+## 执行时间
+
+- 执行日期：2026-06-05
+- 执行人：Codex leader agent，使用本地已登录的 `gh` 身份 `lwnmengjing`
+- 范围：`mss-boot-io/.github`、`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs`
+- 原则：只执行无需外部账号额外决策、无需密钥、无需部署、不会自动合并代码的社区运营动作；涉及 GitHub settings、Cloudflare、Sponsors、Discussions、Projects、branch protection、private vulnerability reporting 的事项继续记入待办。
+
+## 已直接执行的公开动作
+
+### 1. 同步 labels taxonomy
+
+已将组织 `.github/.github/labels.yml` 中的标签同步到以下仓库，使用 `gh label create --force` 幂等创建/更新，不删除旧标签：
+
+- `mss-boot-io/.github`
+- `mss-boot-io/mss-boot`
+- `mss-boot-io/mss-boot-admin`
+- `mss-boot-io/mss-boot-admin-antd`
+- `mss-boot-io/mss-boot-docs`
+
+核心标签包括：
+
+- `area/backend`
+- `area/frontend`
+- `area/docs`
+- `area/devops`
+- `type/bug`
+- `type/feature`
+- `type/question`
+- `type/security`
+- `needs-triage`
+- `needs-info`
+- `candidate/good-first-issue`
+- `good first issue`
+- `help wanted`
+- `release-blocker`
+- `breaking-change`
+
+### 2. 创建首批 good first issue
+
+已创建 12 个低风险、可验证、无需部署/密钥/外部账号的 `good first issue`：
+
+| 仓库 | Issue |
+| --- | --- |
+| `mss-boot-docs` | [#4 docs: add first contribution guide](https://github.com/mss-boot-io/mss-boot-docs/issues/4) |
+| `mss-boot-docs` | [#5 docs: add SECURITY policy FAQ](https://github.com/mss-boot-io/mss-boot-docs/issues/5) |
+| `mss-boot-docs` | [#6 docs: add troubleshooting page for login failures](https://github.com/mss-boot-io/mss-boot-docs/issues/6) |
+| `mss-boot` | [#348 docs: document go test and lint workflow](https://github.com/mss-boot-io/mss-boot/issues/348) |
+| `mss-boot` | [#349 docs: add action/controller glossary](https://github.com/mss-boot-io/mss-boot/issues/349) |
+| `mss-boot` | [#350 test: cover config env template fallback behavior](https://github.com/mss-boot-io/mss-boot/issues/350) |
+| `mss-boot-admin` | [#344 docs: document make test prerequisites](https://github.com/mss-boot-io/mss-boot-admin/issues/344) |
+| `mss-boot-admin` | [#345 docs: add RBAC glossary](https://github.com/mss-boot-io/mss-boot-admin/issues/345) |
+| `mss-boot-admin` | [#346 test: add language middleware fallback coverage](https://github.com/mss-boot-io/mss-boot-admin/issues/346) |
+| `mss-boot-admin-antd` | [#71 docs: add frontend local env matrix](https://github.com/mss-boot-io/mss-boot-admin-antd/issues/71) |
+| `mss-boot-admin-antd` | [#72 docs: fix README badges for frontend workflows](https://github.com/mss-boot-io/mss-boot-admin-antd/issues/72) |
+| `mss-boot-admin-antd` | [#73 docs: align frontend testing commands with package scripts](https://github.com/mss-boot-io/mss-boot-admin-antd/issues/73) |
+
+每个 issue 都包含：
+
+- 背景
+- 修改范围
+- 非目标
+- 验证命令
+- 验收标准
+
+### 3. 历史 issue 轻量分流
+
+对 `mss-boot-admin` 现有 open issue 只做标签分流，不关闭、不自动评论、不替维护者判断结论：
+
+| Issue | 标签处理 |
+| --- | --- |
+| [#139 部署完成后无法正常登录](https://github.com/mss-boot-io/mss-boot-admin/issues/139) | `needs-triage`、`type/bug`、`area/devops`、`needs-info` |
+| [#126 查看在线用户并强退](https://github.com/mss-boot-io/mss-boot-admin/issues/126) | `needs-triage`、`type/feature`、`area/backend`、`help wanted` |
+| [#111 通知支持多种 provider](https://github.com/mss-boot-io/mss-boot-admin/issues/111) | `needs-triage`、`type/feature`、`area/backend`、`help wanted` |
+| [#105 数据更新后查询未刷新](https://github.com/mss-boot-io/mss-boot-admin/issues/105) | `needs-triage`、`type/bug`、`area/backend`、`needs-info` |
+| [#89 migration 支持纯 SQL 和回滚](https://github.com/mss-boot-io/mss-boot-admin/issues/89) | `needs-triage`、`type/feature`、`area/backend` |
+| [#87 修改首次 migration](https://github.com/mss-boot-io/mss-boot-admin/issues/87) | `needs-triage`、`type/feature`、`area/backend` |
+| [#75 Bug Report](https://github.com/mss-boot-io/mss-boot-admin/issues/75) | `needs-triage`、`type/bug`、`area/backend`、`needs-info` |
+| [#73 虚拟模型支持关联模型](https://github.com/mss-boot-io/mss-boot-admin/issues/73) | `needs-triage`、`type/feature`、`area/backend` |
+| [#55 数据统计功能实现](https://github.com/mss-boot-io/mss-boot-admin/issues/55) | `needs-triage`、`type/feature`、`area/backend` |
+| [#53 手机号登录功能](https://github.com/mss-boot-io/mss-boot-admin/issues/53) | `needs-triage`、`type/feature`、`area/backend` |
+
+### 4. Dependabot PR 队列化
+
+对现有 Dependabot PR 增加 `needs-triage` 与 `area/backend`，不自动合并：
+
+- `mss-boot`：#341、#342、#343、#344、#345、#346、#347
+- `mss-boot-admin`：#337、#338、#339、#340、#341
+
+## 不直接执行的事项
+
+以下事项已确认需要外部账号设置、组织权限策略或维护者决策，继续保留在 `open-source-operations-backlog.zh-CN.md`：
+
+- GitHub branch protection / rulesets
+- required checks
+- private vulnerability reporting
+- secret scanning / push protection
+- Discussions 分类与启用
+- GitHub Projects 看板
+- Sponsors / FUNDING
+- Cloudflare 发布与域名设置
+- 自动关闭历史 issue
+- 自动合并 Dependabot PR
+
+## 验收记录
+
+- `gh auth status` 显示已登录 `github.com`，身份为 `lwnmengjing`。
+- 四核心仓库均能查询到新建的 `good first issue`。
+- `mss-boot-admin` 历史 open issue 已包含新的 taxonomy 标签。
+- Dependabot PR 已通过 REST issue labels API 加入 triage 队列标签。
+
+## 后续复核
+
+本次公开运营动作已经直接生效，但本地源码侧社区健康文件、workflow 和文档仍需通过对应仓库的分支/PR 发布到 GitHub 后，GitHub Community Profile 与 Scorecard 才会反映新的治理状态。

--- a/aigc/prompts/open-source-good-first-issue-factory.zh-CN.md
+++ b/aigc/prompts/open-source-good-first-issue-factory.zh-CN.md
@@ -1,0 +1,64 @@
+# mss-boot-io good first issue 任务工厂
+
+## 记录时间
+
+- 记录时间：2026-06-05
+- 目标：为个人维护者准备低成本、可验证、适合 AI 辅助生成 issue 的社区任务池。
+- 使用方式：Maintainer 从本文件挑选任务，确认范围后创建 GitHub issue，并打 `good first issue` 或 `candidate/good-first-issue`。
+
+## 任务创建模板
+
+每个 issue 建议包含：
+
+- 背景：为什么需要这个任务。
+- 修改范围：允许改哪些文件，避免新人误改架构。
+- 非目标：明确不做的内容。
+- 验证命令：本地命令或文档构建命令。
+- 验收标准：review 时如何判断完成。
+
+## 候选任务
+
+2026-06-05 已从下表中直接创建 12 个首批公开 `good first issue`：
+
+- `mss-boot-docs`：#4、#5、#6
+- `mss-boot`：#348、#349、#350
+- `mss-boot-admin`：#344、#345、#346
+- `mss-boot-admin-antd`：#71、#72、#73
+
+后续继续创建 issue 时，应先检查同名 issue 是否已存在，避免重复。
+
+| # | 仓库 | 标题 | 修改范围 | 验证命令 | 验收标准 |
+| ---: | --- | --- | --- | --- | --- |
+| 1 | `mss-boot-docs` | `docs: add alpha/beta/prod environment quick reference` | `docs/devops/**` | `pnpm build` | 页面清楚说明三个环境、域名、发布门禁，不含凭据。 |
+| 2 | `mss-boot-docs` | `docs: add SECURITY policy FAQ` | `docs/devops/**` 或 `docs/admin/**` | `pnpm build` | 用户知道漏洞不要发 public issue，知道如何提供复现。 |
+| 3 | `mss-boot-docs` | `docs: add first contribution guide` | `docs/coding/**` | `pnpm build` | 新贡献者 30 分钟内能找到 fork、安装、测试、PR 流程。 |
+| 4 | `mss-boot-docs` | `docs: add release checklist page` | `docs/devops/**` | `pnpm build` | 包含后端镜像、前端 Cloudflare、回滚、冒烟清单。 |
+| 5 | `mss-boot-docs` | `docs: add troubleshooting page for login failures` | `docs/admin/**` | `pnpm build` | 覆盖 401、token 过期、菜单为空、API 域名错误。 |
+| 6 | `mss-boot` | `docs: document go test and lint workflow` | `README.md`、`README.Zh-cn.md` | `go test ./...` | README 中有清晰本地验证命令。 |
+| 7 | `mss-boot` | `test: add small test for config default behavior` | `pkg/config/**` | `go test ./...` | 增加低风险单元测试，不改变配置语义。 |
+| 8 | `mss-boot` | `docs: add action/controller glossary` | `README.md` 或 docs 链接 | `go test ./...` | 新人能理解 Controller、Action、Hook、Scope 基本含义。 |
+| 9 | `mss-boot` | `ci: add workflow badge section to README` | `README.md`、`README.Zh-cn.md` | 不需要构建 | badge 指向 CI、CodeQL、Scorecard。 |
+| 10 | `mss-boot-admin` | `docs: document make test prerequisites` | `README.md`、`README.zh-CN.md` | `make test` | 说明 Redis、数据库或 mock 需求，避免新人跑不通。 |
+| 11 | `mss-boot-admin` | `docs: add API smoke test commands` | `README.md`、`README.zh-CN.md` | `make test` | 给出健康检查、登录、配置接口的 curl 示例，不含真实密码。 |
+| 12 | `mss-boot-admin` | `test: add unit test for language public API edge case` | `apis/**`、`service/**` 测试文件 | `make test` | 覆盖空 header/默认语言场景。 |
+| 13 | `mss-boot-admin` | `docs: add RBAC glossary` | `README.zh-CN.md` 或 docs | `make test` | 解释用户、角色、菜单、API、数据范围。 |
+| 14 | `mss-boot-admin` | `ci: document image tag strategy` | `README.md`、`README.zh-CN.md` | 不需要构建 | 说明 branch tag、commit SHA tag、release tag 的区别。 |
+| 15 | `mss-boot-admin-antd` | `docs: add frontend local env matrix` | `README.md`、`README.zh-CN.md` | `pnpm tsc` | 说明 dev/alpha/beta/prod 对应 API 域名和命令。 |
+| 16 | `mss-boot-admin-antd` | `test: add smoke test for app config page route` | `tests/**` 或 Playwright 测试 | `pnpm test` 或 `pnpm test:e2e` | 能验证页面渲染和关键接口错误提示。 |
+| 17 | `mss-boot-admin-antd` | `docs: add Cloudflare release checklist` | `README.md`、`README.zh-CN.md` | `pnpm build:local` | 明确不能高频发布，beta 必须冒烟通过。 |
+| 18 | `mss-boot-admin-antd` | `ci: add README badges for CI and CodeQL` | `README.md`、`README.zh-CN.md` | 不需要构建 | badge 指向 CI、CodeQL、Scorecard。 |
+| 19 | `.github` | `docs: add label taxonomy usage guide` | `.github/README.md` 或 docs | 不需要构建 | 说明 `area/*`、`type/*`、`needs-*` 标签含义。 |
+| 20 | `.github` | `ci: add label sync workflow proposal` | `.github/workflows/**` 或 backlog | 不需要构建 | 只生成提案或手动 workflow，不自动覆盖未知标签。 |
+
+## 不适合作为 good first issue 的任务
+
+- 权限模型重构、去多租户重构、认证流程调整。
+- 数据库迁移、生产发布、Cloudflare 发布。
+- Kubernetes Secret、Cloudflare Token、GitHub org settings。
+- 大范围格式化或无明确验收标准的重构。
+
+## AI 辅助规则
+
+- AI 可以把本文件中的候选任务扩展成 issue 草稿。
+- AI 不应自动创建大量 public issues；先由 Maintainer 挑选和确认。
+- AI 可以在 Weekly Digest 中推荐 `candidate/good-first-issue`，但正式 `good first issue` 标签应由 Maintainer 确认。

--- a/aigc/prompts/open-source-operations-backlog.zh-CN.md
+++ b/aigc/prompts/open-source-operations-backlog.zh-CN.md
@@ -1,0 +1,68 @@
+# mss-boot-io 开源组织外部运营待办
+
+## 记录时间
+
+- 记录时间：2026-06-05
+- 适用范围：`mss-boot-io` GitHub 组织与四个核心仓库
+- 背景：本地已补齐可通过源码落地的社区健康、CI、安全扫描和 AI 自动化。以下事项需要 GitHub/Cloudflare/赞助平台等外部账号权限或维护者决策，不能仅靠本地文件完成。
+
+## P0：影响 9.2+ 真实评分的外部设置
+
+| 事项 | 建议配置 | 原因 | 执行人 |
+| --- | --- | --- | --- |
+| 合并组织 `.github` 仓库变更 | 将默认社区健康文件和 reusable workflows 发布到 `mss-boot-io/.github@main` | 组织默认模板和 reusable workflows 只有发布后才会被其他仓库使用 | Maintainer |
+| Branch protection / rulesets | 保护 `main`，禁止 force push，要求 PR，要求 CI、CodeQL、govulncheck、Scorecard 通过 | OpenSSF Scorecard 与真实贡献门禁都依赖此设置 | Maintainer |
+| Required checks | Go 仓：CI、CodeQL、govulncheck、Scorecard；前端/文档：CI、CodeQL、Scorecard | 防止未验证改动进入主分支 | Maintainer |
+| Private vulnerability reporting | 对核心仓库启用 GitHub private vulnerability reporting | 避免漏洞通过 public issue 披露 | Maintainer |
+| Security contact | 决定公开安全邮箱或 GitHub Advisories-only 策略 | `SECURITY.md` 当前记录为待定，需最终入口 | Maintainer |
+| Secret scanning / push protection | GitHub Advanced Security 可用时开启；免费能力可先依赖 secret scanning alert | 降低密钥泄漏风险 | Maintainer |
+| Dependabot security updates | 启用 security updates 与 grouped version updates | 依赖安全修复自动化 | Maintainer |
+
+## P1：低成本社区运营设置
+
+| 事项 | 建议配置 | 原因 | 执行人 |
+| --- | --- | --- | --- |
+| GitHub Discussions | 分类：Q&A、RFC、Roadmap、Help Wanted、中文交流 | 把答疑从 issue 中分流，减少维护负担 | Maintainer |
+| Labels 同步 | 按组织 `.github/.github/labels.yml` 同步到四核心仓库 | 让 Issue Triage/Weekly Digest 输出可用 | Maintainer 或自动脚本 |
+| Good first issue 批量创建 | 先从任务工厂挑 10 个，确认范围后创建 | 给外部贡献者 30 分钟可参与入口 | Maintainer |
+| GitHub Projects | 建一个 lightweight board：Triage、Ready、In Progress、Review、Done | 个人维护者低成本看板 | Maintainer |
+| 月报节奏 | 每月从 Weekly Digest 汇总成公开运营月报 | 用 AI 辅助生成，降低社区运营成本 | Doc/Leader |
+
+## P2：赞助与外部分发
+
+| 事项 | 建议配置 | 原因 | 执行人 |
+| --- | --- | --- | --- |
+| GitHub Sponsors / FUNDING | 由用户决定收款主体、平台和展示口径后再启用 | 涉及外部账号和财务主体 | Maintainer |
+| 中文内容分发 | README/docs 为主，掘金/公众号/Bilibili 只同步高价值内容 | 少渠道、低维护、可复用 | Maintainer |
+| 社群 webhook | 暂不接 Slack/飞书/Discord 自动推送，除非已有稳定社区渠道 | 避免维护额外机器人和泄漏 token | Maintainer |
+| 跨仓组织周报 | 需要 org-level PAT 或 GitHub App | `GITHUB_TOKEN` 只能稳定操作当前仓库 | Maintainer |
+
+## P3：后续供应链增强
+
+| 事项 | 建议配置 | 原因 | 执行人 |
+| --- | --- | --- | --- |
+| SBOM | tag release 生成 SBOM artifact | 增强可审计发布 | Release/Security |
+| Artifact attestation | 后端镜像与前端产物添加 provenance/attestation | 提升供应链可信度 | Release/Security |
+| Docker image scanning | Trivy 或 GHCR scanning | 镜像依赖风险可见 | Security |
+| CODEOWNERS | 确认真实 reviewer 后再落地 | 不能虚构不存在的 team/user | Maintainer |
+
+## 暂不建议自动化的事项
+
+- 自动 merge：风险高，个人维护阶段先不要开。
+- 自动 close issue：容易误伤新贡献者，先只打 `needs-info` 和评论。
+- LLM 自动改代码后直发：不符合开源维护责任边界。
+- Cloudflare 前端高频预览发布：与当前发布策略冲突，会消耗次数并污染公开 beta。
+
+## 验收方式
+
+外部设置完成后，记录：
+
+- 仓库名
+- 设置项
+- 执行时间
+- 执行人
+- 截图或 `gh api` 导出片段
+- 对应 required checks
+- 是否影响 alpha/beta/prod 发布策略
+
+该记录应追加到本文件或后续治理记录文档中。

--- a/aigc/prompts/organization-memory.zh-CN.md
+++ b/aigc/prompts/organization-memory.zh-CN.md
@@ -1,0 +1,204 @@
+# mss-boot-io 组织级 AI 记忆
+
+## 记忆来源
+
+- 读取时间：2026-06-04
+- 更新确认：2026-06-04，`mss-boot-admin` 与 `mss-boot-admin-antd` 已补齐 `aigc` 目录
+- 工作区：`/Users/linwenxiang/go/src/github.com/mss-boot-io`
+- 工作区形态：多 Git 仓库并列的 workspace，`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 各自是独立 Git 仓库。
+- 关键约束：组织级记忆、跨仓库流程、发布策略和多 agent 协作规则必须落盘到 `mss-boot-docs`，否则在多 Git workspace 中容易随单仓上下文切换而丢失。
+- 已发现的 `aigc` 目录：
+  - `mss-boot/aigc`
+  - `mss-boot-admin/aigc`
+  - `mss-boot-admin-antd/aigc`
+  - `mss-boot-docs/aigc`
+- 组织级文档项目：`mss-boot-docs`
+
+## 组织项目地图
+
+`mss-boot-io` 当前工作区由四个核心仓库组成：
+
+- `mss-boot`：企业级微服务基础框架，主责 HTTP/Gin、gRPC、配置、响应抽象、鉴权、安全、存储、任务、可观测与虚拟资源等框架能力。
+- `mss-boot-admin`：基于 `mss-boot` 的后台服务，主责权限治理、组织管理、系统配置、通知任务、国际化、监控统计、OAuth2/Token、上传、事件等业务后台能力。
+- `mss-boot-admin-antd`：基于 React、Ant Design v5、Umi Max v4 的前端管理台，页面与服务接口大体对应后端 API 模块。
+- `mss-boot-docs`：组织级文档项目，基于 Dumi 构建，承接框架指南、Admin 产品文档、测试沉淀、交接说明、AI 注解协同规范和跨仓库协作记忆。
+
+## 核心产品定位
+
+- `mss-boot` 是框架底座，目标是在服务代码保持极简的前提下，提供完善工程化和扩展能力。
+- `mss-boot-admin` 是开箱即用的单租户后台管理系统，当前产品主线聚焦权限治理、组织管理、系统配置、通知任务、国际化、监控统计与 AI 注解协同。
+- 动态模型、虚拟模型、代码生成、多租户相关实现可能仍存在于代码中，但在文档中已被标记为历史存量或非主线能力；改动前应先确认目标是维护兼容、降级弱化，还是彻底清理。
+- `mss-boot-docs` 是组织级知识入口，跨项目说明默认应优先沉淀到这里，而不是分散到业务仓库根目录。
+
+## 当前阶段记忆
+
+- 三期治理与运营能力补强已有交接记录，包含 CustomDept 数据权限自动填充、WebSocket 实时通知、登录与操作审计日志、扩展监控维度、Playwright E2E 测试。
+- P3 AI 注解协同流程落地已评估为完成，重要改动应通过评审、计划、交接、评估四类产物沉淀。
+- P4 集成与扩展护栏已评估为完成，国际化、对象存储/上传、WebSocket、API-first 扩展能力应纳入治理、安全、文档和测试检查清单。
+- P5 历史能力降级与叙事收口已评估为完成，动态模型与模板/代码生成均为 L3 弱化能力：保留但非主线，生产环境建议使用标准 Controller 模式。
+- 产品叙事应避免把 `mss-boot-admin` 表述为低代码平台或以动态模型/代码生成为核心卖点。
+- 2026-06-04 已在 `~/.kube/baas.yaml` 集群部署的 `mss-boot-dev` 后续归类为 alpha/dev 开发环境，外部域名规划改为 `https://admin-alpha.mss-boot-io.top`；本地启动的前端默认对接 alpha 后端。完整发布环境策略见 `mss-boot-docs/aigc/prompts/release-environment-strategy.zh-CN.md`。
+- beta 对外展示环境改为独立 namespace `mss-boot-beta`：Cloudflare 前端 `https://admin-beta.mss-boot-io.top` 对接后端 API `https://admin-api-beta.mss-boot-io.top`。`mss-boot-beta` 配置复制 `mss-boot-dev` 形态，但数据库和 Redis 复用 dev 实例时必须使用新库/独立 Redis 空间，避免污染 dev 数据。
+- prod 环境规划为新部署 namespace `mss-boot-prod`：Cloudflare 前端 `https://admin.mss-boot-io.top` 对应 prod 后端，后端只部署打 tag 的版本；prod 数据库、Redis、Secret、外部集成配置应独立于 dev/beta。
+- 当前后端 GitHub 镜像运行时缺少 `Asia/Shanghai` 时区数据，Postgres DSN 在 Kubernetes Secret 中使用 `TimeZone=UTC`；若未来镜像内补齐 tzdata 或嵌入 Go timezone 数据，再评估恢复业务期望时区。
+- `mss-boot-dev` 的运行凭据集中在 Kubernetes Secret `mss-boot-runtime`，文档和记忆中只记录资源名和配置形态，不写入明文密码、Token 或完整 DSN。
+- 前后端发布节奏区分：后端可较频繁发布到 alpha/dev 和 beta，优先用 commit SHA tag 或 digest 记录；前端不能随意发布 Cloudflare，必须等功能完整、可对外公开且冒烟通过后再发布。`admin-beta` 是外部展示环境，必须展示发布前完整功能，不能暴露半成品。
+- 2026-06-04 `/app-config` 弹框问题是在旧拓扑下用 `mss-boot-dev` 验证修复：`codex/fix-language-public-beta` 发布 `ghcr.io/mss-boot-io/mss-boot-admin:351b50db09a8ccd02d3197383e5434aeff4aa73f`，`mss-boot-dev` 已更新到该 SHA；`/admin/api/languages/public?pageSize=999`、`/admin/api/app-configs/profile`、`/admin/api/app-configs/base` 均返回 200。后续按新拓扑应将对外 beta 展示切到 `mss-boot-beta`。
+- 2026-06-04 基于 GitHub 当前数据完成开源组织评分与 AI 时代增长方案，当前综合评分为 6.4/10；核心路线是将 `mss-boot-io` 打造成 agent-readable、governance-first、production-maintainable 的 Go 微服务后台开源组织。详细方案见 `mss-boot-docs/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md`。
+- 2026-06-05 执行开源组织评分提升实施：新增/完善组织级 `.github` 社区健康文件、默认 issue/PR 模板、标签规范、reusable workflows；四核心仓库补齐 Scorecard、govulncheck/CodeQL、Dependabot、PR Guard、Issue Triage、Docs Drift、Weekly Digest、Release Draft、社区健康文件与 CI 门禁；`mss-boot-admin` AI 指令中的多租户/虚拟模型/代码生成已调整为历史兼容能力。可直接通过源码实现的开源组织化能力已推进到 9.2+ 准备态，真实公开评分仍依赖 GitHub 外部设置完成。
+- 2026-06-05 使用 `gh` 复核 GitHub 公网状态：可见仓库 38 个，公开 34 个，私有 4 个，总 stars 128，总 forks 39；社区健康分为 `.github` 12、`mss-boot` 62、`mss-boot-admin` 75、`mss-boot-admin-antd` 62、`mss-boot-docs` 37。该结果反映的是 main 分支公网状态，不包含本地尚未提交/推送的治理改动；后续推送合并并完成外部设置后需重新复核。
+- 2026-06-05 外部账号/组织设置待办已落盘到 `mss-boot-docs/aigc/prompts/open-source-operations-backlog.zh-CN.md`；good first issue 任务工厂已落盘到 `mss-boot-docs/aigc/prompts/open-source-good-first-issue-factory.zh-CN.md`。
+- 2026-06-05 为保证新增 CI 门禁不是“纸面门禁”，同步修复 `mss-boot` 与 `mss-boot-admin-antd` 的测试基线：`mss-boot` 全量 `go test ./...` 可在无外部 Redis/MySQL/AWS SSO 时通过；`mss-boot-admin-antd` 在 Node 18 + pnpm 9 下通过 frozen install、`pnpm tsc`、`pnpm lint:js`、`pnpm test -- --runInBand`、`pnpm build:local`。本地 Node 24 不适合该前端仓库的 Umi 4.0.x 工具链验证。
+- 2026-06-05 已执行可直接落地的社区运营动作：同步 `.github`、`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 的 labels taxonomy；创建 12 个低风险 `good first issue`；给 `mss-boot-admin` 历史 open issue 做轻量标签分流；给 `mss-boot` 与 `mss-boot-admin` 的 Dependabot PR 增加 `needs-triage` 与 `area/backend`。执行记录见 `mss-boot-docs/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md`。
+
+## 角色协作记忆
+
+默认采用面向开源组织的 leader-first 多 agent 工作方式：
+
+- 后续复杂交付默认开启多 agent 工作流，完整规则见 `mss-boot-docs/aigc/prompts/multi-agent-delivery-workflow.zh-CN.md`；该流程已从普通项目交付升级为开源组织治理流程，目标是公开可追溯、可复现、可审计、可维护。
+- 用户默认与 leader 沟通，leader 负责目标、范围、优先级、阶段边界、里程碑识别、agent 协调、返工闭环、验收汇总和对外总结，角色入口在 `mss-boot-admin/aigc/prompts/roles/leader-role.zh-CN.md`。
+- 面向社区协作时，先由 triage agent 做 issue/需求分流：确认问题类型、复现信息、影响仓库、优先级、是否需要 RFC/ADR。
+- PM agent 先理解需求并出方案；leader 审核方案是否符合项目要求、开源质量要求和用户真实需求，再拆分执行。
+- 架构设计师主责 `mss-boot`，负责框架边界、抽象治理和长期演进。
+- 后端开发主责 `mss-boot-admin`，负责 API、DTO、模型、服务、权限、配置和业务逻辑，角色入口在 `mss-boot-admin/aigc/prompts/roles/backend-developer-role.zh-CN.md`。
+- 后台前端 admin agent 主责 `mss-boot-admin-antd`，负责页面、路由、状态、服务对接、交互体验、本地验证和 Cloudflare 发布前准备，角色入口在 `mss-boot-admin-antd/aigc/prompts/roles/frontend-developer-role.zh-CN.md`。
+- 文档整理 doc agent 主责 `mss-boot-docs` 与各仓库 `aigc/prompts/`，负责方案、交接、测试结论、发布信息和组织记忆沉淀。
+- 测试 test agent 负责联调验证、冒烟测试、回归结论和失败复现；发现问题直接退回 leader 返工。
+- security agent 负责密钥、权限、依赖、镜像、配置和发布链路风险检查；release agent 负责 changelog、版本说明、镜像/Cloudflare 发布清单和回滚信息。
+- architect 与 leader 在测试和安全检查通过后共同 review 代码和架构；review 有问题则回到 leader，leader 再协调对应 agent 修复。
+
+当任务涉及联调、验收、回归或交接，应尽早引入开发测试视角，并把验证入口、测试数据、风险点和结论沉淀到 `mss-boot-docs`。
+
+多 agent 交付闭环为：`Triage 分流 -> PM 方案 -> Leader 审核 -> 必要时 RFC/ADR -> Backend/Admin/Doc 分工 -> Leader 集成验收 -> Test 测试 -> Security 检查 -> Architect + Leader Review -> Release 整理 -> Doc 落盘 -> Leader/Maintainer 汇总`。测试、安全或 review 不通过时回到 Leader 返工，循环直到满足要求。
+
+开源组织门禁默认包括：issue/PR 信息完整、跨仓影响清楚、公共 API/schema/权限/认证变更有设计记录、测试证据可复现、安全风险已检查、文档和 changelog 同步、发布镜像或前端版本可追踪。
+
+若用户仅回复 `1`，默认解释为继续当前任务或执行下一步；如果有多条分支，优先推进当前主任务路径上优先级最高的下一步。
+
+## 架构记忆
+
+- `Action + Controller` 是 `mss-boot` / `mss-boot-admin` 的核心生产力来源，当前结论是优先保留主架构，不做高风险重写。
+- 资源动作语义优先于 ORM 细节：Controller 表达资源动作，Action 执行动作，Provider 适配 GORM / MGM / K8S 等后端。
+- Hook + Scope 是多租户、鉴权、审计、统计、缓存清理等横切能力的统一注入点，但需要治理执行顺序、错误语义和幂等性。
+- 主要风险是 Router -> Controller -> Action -> Hook -> DB 调用链较长，复杂问题需要跨层排查。
+- 演进优先级：先补 Action 链路可观测性，再规范 Hook，再对热点模块拆分复杂 `Control`，最后推进类型化与生成增强。
+- 新模块优先使用显式 `Create` / `Update` 分离；旧模块按错误率和改动频率逐步治理。
+
+## 单租户化记忆
+
+- 当前产品方向已从多租户叙事收敛到单租户后台系统，多租户相关实现仍可能存在于代码中。
+- 后端去多租户评估基线认为：`mss-boot-admin` 触点约 47 个文件，`mss-boot` 触点约 9 个文件，属于中大型重构。
+- 去多租户推荐 PR 顺序：核心骨架去租户、模型与控制器去租户、缓存/存储/虚拟模型收口、迁移与文档收尾。
+- 高风险点：鉴权与数据范围变化导致权限放大、迁移脚本与 `tenant_id` 索引处理不完整、虚拟模型 `MultiTenant` 语义变化。
+- 缓存结论需按条件理解：若保留多租户，应补 tenant-aware key/helper 与失效治理；若推进单租户化，应同步重构缓存 key 与失效逻辑，避免旧 tenant 前缀残留。
+- 前端多租户主要集中在 `/tenant` 路由、`Tenant` 页面、`tenant.ts` 服务、`typings.d.ts`、`multiTenant` 字段和 i18n 文案，尚未形成统一租户上下文驱动请求架构。
+- 前端去多租户推荐顺序：下线路由与菜单文案、删除页面和 API 客户端、更新 typings 与 `multiTenant` 展示逻辑、执行 lint/build/关键页面回归并联调后端。
+
+## 工程行为准则
+
+- 改代码前先定位所属仓库和责任边界，不把业务修复误上升为框架改造。
+- 优先做最小侵入改动，沿用既有包结构、命名、Option 模式、Controller/Action 分层和服务组织方式。
+- 新增 HTTP 资源能力时，优先复用 `pkg/response/controller` 和已有 action 模式。
+- 配置能力优先复用 `pkg/config.Init` 与既有 provider 机制。
+- HTTP 鉴权优先沿用 `response.AuthHandler` 和现有中间件体系。
+- 修改后优先执行与变更点强相关的测试，再考虑大范围校验。
+- 发现文档与代码不一致时，先说明证据来源和时间点，不在没有证据时判定问题归属。
+
+## 目录与命令记忆
+
+### mss-boot
+
+- 模块名：`github.com/mss-boot-io/mss-boot`
+- Go 版本：`go 1.26`
+- 关键目录：
+  - `core/`：服务管理、日志与运行时组件
+  - `pkg/config/`：配置结构与 Provider 能力
+  - `pkg/response/`：Controller、Action、返回与错误抽象
+  - `pkg/middlewares/`：认证、限流、用户上下文
+  - `pkg/security/`、`pkg/store/`：安全与 OAuth2 相关能力
+  - `virtual/`：虚拟资源模型、API 和 Action 编排
+  - `proto/`：gRPC 协议定义与生成文件
+- 常用校验：`go test ./...`
+
+### mss-boot-admin
+
+- 模块名：`github.com/mss-boot-io/mss-boot-admin`
+- Go 版本：`go 1.25.3`
+- 依赖框架：`github.com/mss-boot-io/mss-boot`
+- 关键目录：
+  - `apis/`：后台 API
+  - `models/`：数据模型
+  - `dto/`：请求与响应 DTO
+  - `service/`：业务服务
+  - `router/`：路由装配
+  - `config/`：配置与初始化
+  - `docs/`：Swagger 生成产物
+  - `aigc/prompts/`：后端角色、leader 角色、Action 架构评审、去多租户计划与阶段交接文档
+- 常用命令：
+  - 数据库迁移：`go run main.go migrate`
+  - 生成接口信息：`go run main.go server -a`
+  - 启动服务：`go run main.go server`
+  - 测试：`go test ./...`
+- 当前关键记忆文件：
+  - `aigc/prompts/roles/leader-role.zh-CN.md`
+  - `aigc/prompts/roles/backend-developer-role.zh-CN.md`
+  - `aigc/prompts/action-architecture-review.zh-CN.md`
+  - `aigc/prompts/tenant-removal-handoff-summary.zh-CN.md`
+  - `aigc/prompts/phase3-governance-operations-handoff.zh-CN.md`
+  - `aigc/prompts/p3-ai-annotation-evaluation.zh-CN.md`
+  - `aigc/prompts/p4-extension-guardrails-handoff.zh-CN.md`
+  - `aigc/prompts/p5-legacy-capability-handoff.zh-CN.md`
+
+### mss-boot-admin-antd
+
+- 技术栈：React 18、Ant Design v5、Umi Max v4、TypeScript
+- 关键目录：
+  - `config/routes.ts`：前端路由
+  - `src/pages/`：页面入口
+  - `src/services/admin/`：OpenAPI 生成或维护的接口服务
+  - `src/locales/`：国际化资源
+  - `aigc/prompts/`：前端角色、前端多租户评估、去多租户影响计划与交接摘要
+- 常用命令：
+  - 开发：`pnpm start` 或 `npm run start`
+  - OpenAPI 生成：`npm run openapi`
+  - 类型检查：`npm run tsc`
+  - 测试：`npm run test` 或 `npm run test:coverage`
+- 当前关键记忆文件：
+  - `aigc/prompts/roles/frontend-developer-role.zh-CN.md`
+  - `aigc/prompts/frontend-multi-tenant-cache-evaluation.zh-CN.md`
+  - `aigc/prompts/frontend-tenant-removal-impact-plan.zh-CN.md`
+  - `aigc/prompts/frontend-tenant-removal-handoff-summary.zh-CN.md`
+
+### mss-boot-docs
+
+- 技术栈：Dumi 2
+- 组织定位：组织级文档项目
+- 关键目录：
+  - `docs/`：组织文档内容
+  - `docs/admin/`：Admin 产品、治理、测试、部署、安全与路线图
+  - `docs/coding/`：开发编码指南
+  - `docs/guide/`：框架使用指南
+  - `aigc/prompts/`：AI 角色、协作与提示词记忆
+- 常用命令：
+  - 开发：`pnpm start`
+  - 构建：`pnpm run build`
+
+## 文档与提示词落盘规则
+
+- 当前 workspace 是多 Git 仓库并列结构，不是单仓库；组织级记忆必须以 `mss-boot-docs` 作为长期可信入口。
+- 组织级、跨仓库、发布流程、多 agent 协作、环境拓扑、验收规则等记忆必须落盘到 `mss-boot-docs/aigc/prompts/`，不能只写在业务仓库、临时对话或未持久化上下文中，否则会丢失。
+- 新生成的提示词、AI 记忆和规范文档必须写入对应仓库的 `aigc/prompts/` 或其子目录。
+- 组织级、跨仓库文档优先写入 `mss-boot-docs`；仓库内角色、计划、评审、交接、评估类文档写入对应仓库的 `aigc/prompts/`。
+- 不要把提示词或 AI 记忆文件直接写入仓库根目录。
+- 文件名使用小写英文和连字符，中文版本使用 `.zh-CN.md` 后缀。
+- 同名文件已存在时优先更新原文件；需要保留历史时追加日期后缀。
+- 文档应保持开源协作语气：基于可见代码给出可验证结论，说明评估时点、适用范围、关键假设，不写入凭据、私有地址或个人隐私。
+
+## 后续工作默认判断
+
+- 涉及框架抽象、通用能力、配置 Provider、响应 Action、服务生命周期：优先进入 `mss-boot`。
+- 涉及后台 API、权限、菜单、组织、配置、通知、任务、监控、日志、告警、Token/OAuth2：优先进入 `mss-boot-admin`。
+- 涉及页面、路由、表格表单、国际化显示、接口服务调用：优先进入 `mss-boot-admin-antd`。
+- 涉及说明、测试计划、验收结果、路线图、交接沉淀、AI 注解规范：优先进入 `mss-boot-docs`。
+- 涉及跨仓库需求时，应先收敛目标和边界，再分别实现后端、前端、文档与测试沉淀。
+- 涉及里程碑、收尾或提交时，先检查功能、测试、文档和服务可交付状态，再分别处理多仓库提交与交付汇报。

--- a/aigc/prompts/organization-memory.zh-CN.md
+++ b/aigc/prompts/organization-memory.zh-CN.md
@@ -4,7 +4,7 @@
 
 - 读取时间：2026-06-04
 - 更新确认：2026-06-04，`mss-boot-admin` 与 `mss-boot-admin-antd` 已补齐 `aigc` 目录
-- 工作区：`/Users/linwenxiang/go/src/github.com/mss-boot-io`
+- 工作区：本地多仓库 workspace，根目录形态为 `<workspace>/mss-boot-io`
 - 工作区形态：多 Git 仓库并列的 workspace，`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 各自是独立 Git 仓库。
 - 关键约束：组织级记忆、跨仓库流程、发布策略和多 agent 协作规则必须落盘到 `mss-boot-docs`，否则在多 Git workspace 中容易随单仓上下文切换而丢失。
 - 已发现的 `aigc` 目录：

--- a/aigc/prompts/release-environment-strategy.zh-CN.md
+++ b/aigc/prompts/release-environment-strategy.zh-CN.md
@@ -1,0 +1,75 @@
+# mss-boot-io 发布环境与前后端发布策略
+
+## 环境定位
+
+| 环境 | Kubernetes namespace | 前端域名 | API 域名 | 定位 |
+| --- | --- | --- | --- | --- |
+| alpha / dev | `mss-boot-dev` | `admin-alpha.mss-boot-io.top` | 待实际网关配置确认，推荐 `admin-api-alpha.mss-boot-io.top` | 内部开发、联调、本地前端对接 |
+| beta | `mss-boot-beta` | `admin-beta.mss-boot-io.top` | `admin-api-beta.mss-boot-io.top` | 对外展示、公开预发布、必须冒烟通过 |
+| prod | `mss-boot-prod` | `admin.mss-boot-io.top` | 待正式部署确认，推荐 `admin-api.mss-boot-io.top` | 正式生产环境，后端使用 tag 版本 |
+
+说明：
+
+- `mss-boot-dev` 后续归类为开发/alpha 环境，不再承载对外展示 beta 职责。
+- 本地启动的前端默认对接 alpha 后端域名，用于日常开发联调。
+- `admin-beta.mss-boot-io.top` 是 Cloudflare 上的对外展示前端，必须对接 `admin-api-beta.mss-boot-io.top`。
+- `admin.mss-boot-io.top` 是生产前端，对应集群内新部署的 `mss-boot-prod` 后端。
+
+## 数据与 Redis 策略
+
+- `mss-boot-beta` 的配置可复制 `mss-boot-dev` 的形态，但数据库和 Redis 只复用 dev 的实例，不复用 dev 的业务库/数据空间。
+- beta 必须使用独立数据库、独立 Redis DB index 或独立 key prefix；实际选择在部署时确认并写入发布记录。
+- beta 和 dev 即使复用实例，也应使用独立账号、独立 Secret、最小权限和明确命名，避免误连或权限扩散。
+- prod 必须独立部署数据库、Redis、Secret、对象存储、OAuth 回调和外部集成配置，不复用 dev/beta 资源。
+
+## 后端发布策略
+
+- 后端可以较高频发布到 alpha/dev 和 beta，用于快速验证与展示前准备。
+- 后端发布仍必须保留可追溯信息：分支、commit SHA、镜像 tag/digest、GitHub Actions run、目标 namespace 和回滚镜像。
+- beta 后端可通过 `codex/**` 分支发布镜像并更新 `mss-boot-beta`，但应优先使用 commit SHA tag 或 digest，而不是可变分支状态。
+- prod 后端只部署打 tag 的版本；tag 应对应不可变镜像，并记录 changelog、配置差异和回滚方案。
+
+## 前端发布策略
+
+- 前端不能高频发布到 Cloudflare；Cloudflare 发布次数有限，必须等到功能可以对外公开后再发布。
+- 前端发布流程保持不变：先本地开发、构建、联调和浏览器验证，通过后再发布 Cloudflare。
+- beta 前端发布前必须确认：
+  - 后端 beta API 已部署并健康；
+  - 本地前端已对接目标 API 完成验证；
+  - 对外展示所需功能完整，不发布半成品；
+  - 登录、菜单、权限、主要 CRUD、配置页和关键业务链路冒烟通过；
+  - 无阻断级缺陷；
+  - Release/Leader 明确确认可以对外展示。
+- prod 前端发布前必须确认后端 tag 版本、数据库迁移、生产配置和回滚方案已就绪，并完成生产冒烟。
+
+## 发布门禁
+
+### alpha / dev
+
+- 用于快速集成和开发联调，允许后端频繁更新。
+- 本地前端默认对接 alpha 后端。
+- 可以接受短期不稳定，但不能污染 beta/prod 配置、数据或密钥。
+
+### beta
+
+- 是公开预发布/展示环境，安全等级高于 dev。
+- 后端可较频繁更新，但每次更新后至少执行健康检查和基础 API 冒烟。
+- 前端只有在功能完整且通过冒烟后才能发布 Cloudflare。
+- beta 页面必须展示“发布前完整功能”，不能把半成品暴露为对外展示版本。
+- 每次 beta 前端发布都要记录 Cloudflare deployment、后端镜像、API 域名、冒烟结论和已知问题。
+
+### prod
+
+- 新部署 `mss-boot-prod`。
+- 后端必须使用 tag 版本，不使用临时分支镜像。
+- 发布前必须确认独立生产资源、备份、迁移、回滚和安全配置。
+- 发布后必须执行线上冒烟，并保留回滚窗口。
+
+## 待实现时确认
+
+- alpha API 的最终域名是否采用 `admin-api-alpha.mss-boot-io.top`。
+- prod API 的最终域名是否采用 `admin-api.mss-boot-io.top`。
+- beta Redis 隔离采用独立 DB index、key prefix，还是两者同时使用。
+- beta 新数据库命名规则和数据库账号命名规则。
+- Cloudflare 发布次数限制和发布额度策略。
+- prod 后端 tag 命名规则，例如 `vX.Y.Z` 或其他 release tag 约定。

--- a/docs/devops/open-source-governance.md
+++ b/docs/devops/open-source-governance.md
@@ -1,3 +1,13 @@
+---
+title: Open Source Governance
+order: 10
+nav:
+  order: 5
+  title: "devops"
+description: mss-boot-io open source governance, quality gates, release policy, and AI memory rules
+keywords: [open source, governance, quality gates, release, AI memory]
+---
+
 # Open Source Governance
 
 `mss-boot-io` uses a governance-first open source workflow. The goal is to keep

--- a/docs/devops/open-source-governance.md
+++ b/docs/devops/open-source-governance.md
@@ -1,0 +1,32 @@
+# Open Source Governance
+
+`mss-boot-io` uses a governance-first open source workflow. The goal is to keep
+the project readable by contributors, maintainers, and AI agents.
+
+## Quality Gates
+
+- Pull requests must include tests, documentation impact, security impact, and
+  release impact.
+- Go repositories run CI, CodeQL, govulncheck, Dependabot, and OpenSSF
+  Scorecard.
+- Frontend and docs repositories run CI, CodeQL, Dependabot, and OpenSSF
+  Scorecard.
+- API, config, deployment, or workflow changes should update documentation or AI
+  memory.
+
+## Release Policy
+
+- Alpha/dev is for fast integration.
+- Beta is public preview and must pass smoke testing before frontend Cloudflare
+  deployment.
+- Production uses tagged backend releases and verified frontend deployments.
+
+## Security
+
+Do not report vulnerabilities as public issues. Follow the security policy of
+the affected repository and use private GitHub Security Advisories when enabled.
+
+## AI Memory
+
+Organization-level workflow, release policy, and cross-repository decisions must
+be recorded in `mss-boot-docs/aigc/prompts/`.


### PR DESCRIPTION
## Summary

- add community health files, Dependabot, CI, CodeQL, Scorecard, PR Guard, docs drift, issue triage, weekly digest, and release draft workflows
- document open-source governance direction and AI-era growth plan
- persist multi-agent workflow, release environment strategy, organization memory, community operations backlog, good first issue factory, and the 2026-06-05 community ops execution record

## Tests

- pnpm build
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false

## Docs

- This PR is primarily docs and AI memory. It keeps mss-boot-docs as the durable organization memory source for the multi-git workspace.

## Security

- SECURITY.md and public reporting guidance were added. No secrets, tokens, private DSNs, or Cloudflare credentials are included.

## Release

- Docs deployment workflow is hardened but no Cloudflare deployment is manually triggered by this PR.