### PR TITLE
docs: record governance completion results

### DIFF
--- a/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md
+++ b/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md
@@ -103,13 +103,36 @@
 - 自动关闭历史 issue
 - 自动合并 Dependabot PR
 
+### 5. 治理 PR 发布结果
+
+以下治理改动已通过 PR 发布到默认分支：
+
+| 仓库 | PR | 结果 |
+| --- | --- | --- |
+| `mss-boot-io/.github` | [#1 chore: add organization open source governance baseline](https://github.com/mss-boot-io/.github/pull/1) | 已合并 |
+| `mss-boot-io/.github` | [#2 ci: update pages deploy action](https://github.com/mss-boot-io/.github/pull/2) | 已合并 |
+| `mss-boot-io/mss-boot` | [#351 chore: strengthen open source governance](https://github.com/mss-boot-io/mss-boot/pull/351) | 已合并；`go test ./...`、`govulncheck`、CodeQL、PR Guard、Docs Drift 通过 |
+| `mss-boot-io/mss-boot-admin` | [#347 chore: strengthen open source governance](https://github.com/mss-boot-io/mss-boot-admin/pull/347) | 已合并；`go test ./...`、`govulncheck`、CodeQL、PR Guard、Docs Drift 通过 |
+| `mss-boot-io/mss-boot-admin-antd` | [#74 chore: strengthen frontend governance baseline](https://github.com/mss-boot-io/mss-boot-admin-antd/pull/74) | 已合并；`pnpm tsc`、`pnpm lint:js`、登录单测、`pnpm build:local`、GitHub CI、CodeQL、Cloudflare alpha build、PR Guard、Docs Drift 通过 |
+| `mss-boot-io/mss-boot-docs` | [#7 docs: add open source governance memory](https://github.com/mss-boot-io/mss-boot-docs/pull/7) | 已合并；`pnpm build`、CodeQL、PR Guard、Docs Drift 通过 |
+
+`mss-boot-admin-antd` PR #74 曾触发 CodeQL XSS/open redirect 告警，已在同一 PR 中修复为只允许登录 `redirect` 指向同源路径；合并后 `main` 分支公开 CodeQL open alerts 查询结果为空。
+
 ## 验收记录
 
 - `gh auth status` 显示已登录 `github.com`，身份为 `lwnmengjing`。
 - 四核心仓库均能查询到新建的 `good first issue`。
 - `mss-boot-admin` 历史 open issue 已包含新的 taxonomy 标签。
 - Dependabot PR 已通过 REST issue labels API 加入 triage 队列标签。
+- 每个核心仓库当前都有 3 个打开的 `good first issue`。
+- GitHub Community Profile 公开健康度复核：
+  - `.github`：62
+  - `mss-boot`：87
+  - `mss-boot-admin`：100
+  - `mss-boot-admin-antd`：100
+  - `mss-boot-docs`：87
+- `mss-boot` 与 `mss-boot-docs` 剩余公开健康度缺口主要来自 `content_reports_enabled=false` 等仓库设置项，不是本地文件缺失。
 
 ## 后续复核
 
-本次公开运营动作已经直接生效，但本地源码侧社区健康文件、workflow 和文档仍需通过对应仓库的分支/PR 发布到 GitHub 后，GitHub Community Profile 与 Scorecard 才会反映新的治理状态。
+本次可直接执行的公开运营动作、源码治理文件、workflow 与文档已经发布到 GitHub。后续若维护者完成 branch protection、required checks、content reporting、private vulnerability reporting、Discussions、Projects、Sponsors/FUNDING 等外部设置，应继续追加记录到 `open-source-operations-backlog.zh-CN.md` 或新的执行记录中。

--- a/aigc/prompts/open-source-operations-backlog.zh-CN.md
+++ b/aigc/prompts/open-source-operations-backlog.zh-CN.md
@@ -10,13 +10,13 @@
 
 | 事项 | 建议配置 | 原因 | 执行人 |
 | --- | --- | --- | --- |
-| 合并组织 `.github` 仓库变更 | 将默认社区健康文件和 reusable workflows 发布到 `mss-boot-io/.github@main` | 组织默认模板和 reusable workflows 只有发布后才会被其他仓库使用 | Maintainer |
 | Branch protection / rulesets | 保护 `main`，禁止 force push，要求 PR，要求 CI、CodeQL、govulncheck、Scorecard 通过 | OpenSSF Scorecard 与真实贡献门禁都依赖此设置 | Maintainer |
 | Required checks | Go 仓：CI、CodeQL、govulncheck、Scorecard；前端/文档：CI、CodeQL、Scorecard | 防止未验证改动进入主分支 | Maintainer |
 | Private vulnerability reporting | 对核心仓库启用 GitHub private vulnerability reporting | 避免漏洞通过 public issue 披露 | Maintainer |
 | Security contact | 决定公开安全邮箱或 GitHub Advisories-only 策略 | `SECURITY.md` 当前记录为待定，需最终入口 | Maintainer |
 | Secret scanning / push protection | GitHub Advanced Security 可用时开启；免费能力可先依赖 secret scanning alert | 降低密钥泄漏风险 | Maintainer |
 | Dependabot security updates | 启用 security updates 与 grouped version updates | 依赖安全修复自动化 | Maintainer |
+| Content reporting | 将 `mss-boot`、`mss-boot-docs` 等仓库的 content reporting 打开 | GitHub Community Profile 复核显示这两个仓库 `content_reports_enabled=false`，会影响公开健康度 | Maintainer |
 
 ## P1：低成本社区运营设置
 
@@ -66,3 +66,13 @@
 - 是否影响 alpha/beta/prod 发布策略
 
 该记录应追加到本文件或后续治理记录文档中。
+
+## 2026-06-05 已完成项
+
+- 组织 `.github` 治理基线已合并到 `main`。
+- 核心仓库治理 PR 已合并：`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs`。
+- Labels 已同步到 `.github`、`mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs`。
+- 已创建 12 个低风险 `good first issue`，四个核心仓库各 3 个。
+- 已对 `mss-boot-admin` 历史 open issue 做轻量标签分流。
+- 已对现有 Dependabot PR 增加 triage 标签，不自动合并。
+- 未手动发布 Cloudflare beta/prod；仅 `mss-boot-admin-antd` PR #74 触发并通过已有 Cloudflare alpha build 检查。


### PR DESCRIPTION
## Summary
- record merged governance PRs and validation results
- record current GitHub Community Profile health and remaining external settings
- clarify Cloudflare beta/prod was not manually published

## Docs impact
- updates AI memory under aigc/prompts only
- no public docs navigation or runtime content behavior changed

## Tests / Verification
- pnpm build
- git diff --check
- rg -n "/Users/|linwenxiang|go/src/github.com/mss-boot-io" aigc docs CODE_OF_CONDUCT.md SECURITY.md CONTRIBUTING.md SUPPORT.md .github || true

## Security impact
- documents that mss-boot-admin-antd PR #74 fixed the login redirect CodeQL XSS/open redirect alerts
- no secrets, tokens, private logs, or deployment credentials are added

## Release / compatibility impact
- documentation-only memory update
- no release artifact, migration, rollback, beta/prod Cloudflare publish, or runtime compatibility change