### PR TITLE
docs: add open source ecosystem playbook

### DIFF
--- a/aigc/README.md
+++ b/aigc/README.md
@@ -1,0 +1,35 @@
+# mss-boot-io AI Memory
+
+This directory stores durable organization memory for AI agents and maintainers.
+It is not a scratchpad. Important cross-repository decisions should be recorded
+here so they survive local multi-git workspace changes and context resets.
+
+## Entry Points
+
+- [Organization memory](./prompts/organization-memory.zh-CN.md)
+- [Release environment strategy](./prompts/release-environment-strategy.zh-CN.md)
+- [Multi-agent delivery workflow](./prompts/multi-agent-delivery-workflow.zh-CN.md)
+- [Open source AI-era growth plan](./prompts/open-source-ai-era-growth-plan.zh-CN.md)
+- [Good first issue factory](./prompts/open-source-good-first-issue-factory.zh-CN.md)
+- [Operations backlog](./prompts/open-source-operations-backlog.zh-CN.md)
+- [CI stability incident](./prompts/ci-stability-incident-2026-06-05.zh-CN.md)
+- [Open source ecosystem playbook memory](./prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md)
+
+## Rules
+
+- Record decisions that affect more than one repository.
+- Keep environment and release policy changes in this docs repository first.
+- Do not store secrets, tokens, private endpoints, or account credentials.
+- Prefer concrete commands, file paths, validation evidence, and rollback notes.
+- When a repository-level change is important, record a local `aigc` memory in
+  that repository and summarize the organization-level decision here.
+
+## Maintainer Workflow
+
+1. Before a cross-repository change, read the relevant memory file.
+2. During implementation, update repository-local `aigc` files when behavior or
+   workflow changes.
+3. After implementation, update this organization memory when the decision
+   affects release flow, CI, governance, community operations, or AI workflows.
+4. Link memory updates from PR bodies so PR Guard and Docs Drift can explain the
+   change.

--- a/aigc/prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md
+++ b/aigc/prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md
@@ -1,0 +1,17 @@
+# 2026-06-05 开源生态手册落盘记忆
+
+## 背景
+
+用户要求继续完善开源生态，并尽量把组织评分往 10 分靠近。本轮选择先落地一份文档站页面，把可执行的贡献者路径、AI 运营节奏、发布可信、安全供应链和个人维护者成本控制统一记录。
+
+## 变更
+
+- 新增 `docs/devops/open-source-ecosystem-playbook.md`。
+- 更新 `docs/devops/index.md`，让 DevOps 首页能进入 Governance 和 Ecosystem Playbook。
+- 保持外部账号相关事项不自动操作；GitHub Discussions、Sponsors、Security settings、Cloudflare 发布仍需要维护者确认。
+
+## 后续
+
+- 将 good first issue factory 转换成月度 issue batch。
+- 为三核心交付仓库补 release compatibility matrix。
+- CI 稳定后，再推进 SBOM/provenance、required checks、branch protection 和安全披露设置。

--- a/docs/aigc/index.md
+++ b/docs/aigc/index.md
@@ -1,0 +1,45 @@
+---
+title: AI Memory
+order: 1
+nav:
+  order: 6
+  title: "aigc"
+description: AI memory index for mss-boot-io maintainers and agents
+keywords: [AI, memory, aigc, agents, governance]
+---
+
+# AI Memory
+
+`mss-boot-docs/aigc` is the organization memory center. It records decisions
+that must survive local context resets, multi-git workspace changes, and agent
+handoffs.
+
+## Core Memory
+
+- [Organization memory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/organization-memory.zh-CN.md)
+- [Release environment strategy](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/release-environment-strategy.zh-CN.md)
+- [Multi-agent delivery workflow](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/multi-agent-delivery-workflow.zh-CN.md)
+- [CI stability incident](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/ci-stability-incident-2026-06-05.zh-CN.md)
+
+## Open Source Operations
+
+- [Open source AI-era growth plan](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md)
+- [Open source ecosystem playbook memory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md)
+- [Good first issue factory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-good-first-issue-factory.zh-CN.md)
+- [Operations backlog](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-operations-backlog.zh-CN.md)
+- [Community operations execution](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md)
+
+## Agent Roles
+
+- [Dev/Test role](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/roles/dev-test-role.zh-CN.md)
+- [Role collaboration map](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/roles/role-collaboration-map.zh-CN.md)
+- [Roles index](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/roles/readme.zh-CN.md)
+
+## Update Rules
+
+- Do not store secrets or account credentials.
+- Use repository-local `aigc` memory for local behavior changes.
+- Use this docs repository for organization-level release, CI, community, and
+  multi-agent workflow decisions.
+- Link memory files in PR bodies when workflow, deployment, API contract,
+  community operations, or security policy changes.

--- a/docs/devops/index.md
+++ b/docs/devops/index.md
@@ -5,4 +5,8 @@ nav:
 description: devops指导文档
 keywords: [devops]
 ---
-## 敬请期待...
+
+# DevOps
+
+- [Open Source Governance](./open-source-governance.md)
+- [Open Source Ecosystem Playbook](./open-source-ecosystem-playbook.md)

--- a/docs/devops/open-source-ecosystem-playbook.md
+++ b/docs/devops/open-source-ecosystem-playbook.md
@@ -1,0 +1,120 @@
+---
+title: Open Source Ecosystem Playbook
+order: 11
+nav:
+  order: 5
+  title: "devops"
+description: AI-friendly open source ecosystem playbook for mss-boot-io
+keywords: [open source, community, AI, contributor, governance]
+---
+
+# Open Source Ecosystem Playbook
+
+This playbook turns the `mss-boot-io` open source direction into repeatable
+operations. The target is a personal-maintainer-friendly ecosystem that can move
+toward 10/10 without relying on expensive community operations.
+
+## North Star
+
+`mss-boot-io` should be positioned as an AI-governed Go microservice admin
+framework:
+
+- agent-readable: agents can understand modules, contracts, permissions,
+  tests, and release environments;
+- governance-first: PRs, releases, security, and documentation leave an audit
+  trail;
+- production-maintainable: beta/prod releases are smoke-tested and rollbackable;
+- docs-as-memory: durable decisions are recorded in `mss-boot-docs` and each
+  repository's `aigc` directory.
+
+## Score Ladder
+
+| Score | Standard | Practical signal |
+| --- | --- | --- |
+| 7.5 | Trust baseline | README, license, security policy, CI, CodeQL, Dependabot, PR template, and release notes exist. |
+| 8.5 | Contributor-ready | A newcomer can pick a `good first issue`, run tests, and open a useful PR in 30 minutes. |
+| 9.2 | AI-operated | Weekly digest, issue triage, docs drift checks, PR guard, and AI memory are stable across core repositories. |
+| 10 | Ecosystem-grade | Releases include compatibility matrix, SBOM/provenance, smoke evidence, rollback notes, and a visible contributor loop. |
+
+## Contributor Journey
+
+1. Discover the project from the organization README or docs site.
+2. Pick an issue labeled `good first issue` or `help wanted`.
+3. Read the issue's scope, non-goals, validation commands, and expected output.
+4. Run the repository-specific setup:
+   - Go libraries: `go test ./...`
+   - Admin backend: `make test`
+   - Admin frontend: `pnpm install --frozen-lockfile && pnpm test -- --runInBand`
+   - Docs: `pnpm install --frozen-lockfile && pnpm build`
+5. Open a PR with tests, docs, security, and release impact filled in.
+6. Let CI, CodeQL, govulncheck, Scorecard, PR Guard, and Docs Drift validate the change.
+
+## Issue Factory
+
+Each AI-generated or maintainer-created issue should include:
+
+- background: why the change matters;
+- scope: files or modules that may be changed;
+- non-goals: what should not be changed;
+- validation: exact commands to run;
+- acceptance criteria: how maintainers decide it is done.
+
+Good first issues should prefer docs, tests, examples, small UI fixes, and
+clearly bounded CI improvements. They should not include auth redesign,
+database migration, production deployment, or cross-repository refactors.
+
+## AI Operations Loop
+
+| Cadence | Automation | Maintainer action |
+| --- | --- | --- |
+| Every PR | PR Guard and Docs Drift | Review only real design/security/release decisions. |
+| Daily | Dependabot and security checks | Merge low-risk patches after CI; batch risky upgrades. |
+| Weekly | Weekly Digest | Pick 1 to 3 issues, update labels, publish short notes if useful. |
+| Monthly | Release readiness review | Confirm compatibility, changelog, smoke evidence, and rollback notes. |
+
+AI may draft issue text, summarize CI failures, propose labels, update memory,
+and prepare release notes. AI should not auto-merge code, publish Cloudflare
+frontend releases, close user issues aggressively, or disclose security details
+publicly.
+
+## Release Trust
+
+Public beta and prod should be boring:
+
+- backend beta can move quickly, but prod uses tagged versions;
+- frontend Cloudflare alpha/beta deployments are manual and should happen only
+  after local CI and smoke readiness;
+- docs deploy can remain automatic because it is the public source of truth;
+- each release should link commit, image tag or digest, frontend build, API
+  compatibility, smoke result, and rollback path.
+
+## Security And Supply Chain
+
+Minimum target:
+
+- `SECURITY.md` in each core repository;
+- CodeQL, govulncheck, Dependabot, and OpenSSF Scorecard enabled;
+- private vulnerability reporting enabled in GitHub settings when available;
+- no secrets in issue text, docs, examples, or workflow logs;
+- release artifacts should move toward SBOM and provenance.
+
+## Maintainer Cost Control
+
+For a personal maintainer, the default should be low-noise:
+
+- avoid automatic frontend preview deploys for every PR;
+- keep CI required, but make docs/community checks explainable;
+- group Dependabot updates where possible;
+- rely on AI for triage drafts and summaries, not final judgment;
+- keep public communication in GitHub Issues, Discussions, and docs before
+  adding extra social channels.
+
+## Next Moves
+
+- Keep all core repository main branches green for the latest runs.
+- Merge low-risk CI reliability fixes before enabling stricter required checks.
+- Convert the existing good-first-issue factory into a monthly issue batch.
+- Add a release compatibility matrix for `mss-boot`, `mss-boot-admin`, and
+  `mss-boot-admin-antd`.
+- Add SBOM/provenance as a release hardening milestone after the CI baseline is
+  stable.


### PR DESCRIPTION
## Summary
- add an AI-friendly open source ecosystem playbook to the docs site
- expose the organization AI memory through a public docs index
- add aigc/README.md as the durable memory entry point

## Tests / 验证
- pnpm build
- git diff --check

## Docs / 文档
- Added docs/devops/open-source-ecosystem-playbook.md
- Added docs/aigc/index.md
- Added aigc/README.md
- Added aigc/prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md

## Security / 安全
- Documentation only. No secrets, tokens, or private endpoints are added.

## Release / 发布与回滚
- Docs site change only. It will deploy through the existing docs workflow after merge; rollback is reverting this PR.