### PR TITLE
ci: upgrade action runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
       CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -48,15 +48,15 @@ jobs:
     environment: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scorecard-results.sarif

--- a/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,7 @@
+# Actions runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：组织主干流水线恢复全绿后，GitHub Actions 仍显示 Node.js 20 runtime 与 CodeQL Action v3 弃用提示。文档仓库还承担公开文档部署，因此需要提前消除未来流水线风险。
+- 处理：将 `actions/checkout`、`actions/setup-node`、`actions/setup-go`、`pnpm/action-setup` 升级到 `v6`，将 `github/codeql-action/init|analyze|upload-sarif` 升级到 `v4`。
+- 约束：文档部署保持原触发规则；本次不改 Cloudflare 凭据、不改发布域名。
+- 验收：本地 `pnpm build` 与 PR checks / main checks 双重确认，记忆落盘在 docs 仓库，避免多 git workspace 中丢失上下文。

--- a/docs/admin/integration-test-guide.md
+++ b/docs/admin/integration-test-guide.md
@@ -349,8 +349,8 @@ jobs:
   backend-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
       - name: Run backend tests
@@ -366,11 +366,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: backend-test
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '18'
-      - uses: pnpm/action-setup@v2
+          node-version: '24'
+      - uses: pnpm/action-setup@v6
         with:
           version: 8
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- upgrade checkout/setup-node/setup-go/pnpm setup actions to `v6`
- upgrade CodeQL init/analyze/upload-sarif to `v4`
- refresh the integration-test workflow example and record the context in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- `pnpm build`
- verified `actions/checkout@v6`, `actions/setup-node@v6`, `actions/setup-go@v6`, `pnpm/action-setup@v6`, and `github/codeql-action@v4` tags via GitHub API

## Docs
- Updated `docs/admin/integration-test-guide.md` workflow example.
- Added `aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No docs-site security behavior changes.
- Keeps CodeQL and SARIF upload actions on the supported major version and moves setup actions to Node 24-compatible major versions.

## Release
- Docs workflow behavior is unchanged; only action versions and a docs example are updated.