### PR TITLE
docs: document github-first ai delegation

### DIFF
--- a/aigc/prompts/github-first-ai-ci-delegation-2026-06-05.zh-CN.md
+++ b/aigc/prompts/github-first-ai-ci-delegation-2026-06-05.zh-CN.md
@@ -1,0 +1,9 @@
+# GitHub-first AI 与 CI 委派记忆
+
+- 日期：2026-06-05
+- 决策：开源组织优先使用 GitHub 原生能力承接重复劳动，包括 Actions、Dependabot、CodeQL、govulncheck、Scorecard、PR Guard、Docs Drift，以及可用时的 Copilot code review、Copilot coding agent、Copilot issue drafting、Copilot Autofix。
+- 原则：能由 GitHub workflow 稳定完成的检查和低风险自动化，落到 workflow；需要组织策略、Copilot 订阅、Actions minutes 或安全设置的能力，先记录为外部配置项，等待维护者确认。
+- 边界：AI 和流水线可以做检查、总结、草拟、建议、低风险实现；维护者保留架构、安全、发布、合并和对外沟通的最终判断。
+- 当前落地：本轮已将多个仓库的 Actions runtime 升级到 Node 24-compatible major，并通过 PR/main checks 验证；前端 Cloudflare alpha/beta 发布仍保持手动。
+- 后续待确认：是否开启/配置 Copilot automatic code review、Copilot coding agent issue assignment、CodeQL Copilot Autofix、private vulnerability reporting、GitHub Discussions。
+

--- a/docs/aigc/index.md
+++ b/docs/aigc/index.md
@@ -25,6 +25,7 @@ handoffs.
 
 - [Open source AI-era growth plan](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md)
 - [Open source ecosystem playbook memory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md)
+- [GitHub-first AI and CI delegation](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/github-first-ai-ci-delegation-2026-06-05.zh-CN.md)
 - [Good first issue factory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-good-first-issue-factory.zh-CN.md)
 - [Operations backlog](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-operations-backlog.zh-CN.md)
 - [Community operations execution](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md)

--- a/docs/devops/open-source-ecosystem-playbook.md
+++ b/docs/devops/open-source-ecosystem-playbook.md
@@ -77,6 +77,32 @@ and prepare release notes. AI should not auto-merge code, publish Cloudflare
 frontend releases, close user issues aggressively, or disclose security details
 publicly.
 
+## GitHub-First AI And CI Delegation
+
+Prefer GitHub-native automation before adding external SaaS, self-hosted bots,
+or maintainer-only scripts. The default split is:
+
+| Work | GitHub-owned path | Maintainer boundary |
+| --- | --- | --- |
+| Pull request hygiene | PR Guard, Docs Drift, CodeQL, govulncheck, Scorecard, required checks | Decide architecture, security risk, release timing, and merge approval. |
+| Dependency updates | Dependabot PRs and grouped GitHub Actions upgrades | Batch risky upgrades; keep low-risk action/runtime updates green and quiet. |
+| Security alerts | CodeQL code scanning and Copilot Autofix for public repositories | Review generated fixes before merge; never disclose private vulnerability context publicly. |
+| Review assistance | Copilot code review when enabled for the organization | Treat comments as advisory; maintainer remains accountable for acceptance. |
+| Issue drafting | GitHub Copilot issue creation/update and issue forms | Maintainer approves scope, labels, priority, and whether Copilot may be assigned. |
+| Implementation delegation | Copilot coding agent on bounded issues when enabled | Use only for low-to-medium-risk tasks with clear tests and non-goals. |
+
+Capabilities that are already safe to rely on in public CI should be encoded in
+workflow files. Capabilities that depend on organization policy, Copilot plans,
+GitHub Actions minutes, or security settings must be tracked as pending external
+configuration before use.
+
+Useful GitHub references:
+
+- [Copilot code review](https://docs.github.com/en/copilot/concepts/agents/code-review)
+- [Copilot coding agent](https://docs.github.com/en/copilot/concepts/coding-agent/coding-agent)
+- [Copilot issue creation and updates](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-to-create-or-update-issues)
+- [Copilot Autofix for code scanning](https://docs.github.com/en/code-security/concepts/code-scanning/copilot-autofix-for-code-scanning)
+
 ## Release Trust
 
 Public beta and prod should be boring:


### PR DESCRIPTION
## Summary
- add a GitHub-first AI and CI delegation section to the open-source ecosystem playbook
- document which tasks should be handled by GitHub Actions, Dependabot, CodeQL/Copilot Autofix, Copilot code review, issue drafting, and Copilot coding agent
- record the organization-level decision in `aigc/prompts`

## Tests
- `git diff --check`
- `pnpm build`

## Docs
- Updated `docs/devops/open-source-ecosystem-playbook.md`.
- Updated `docs/aigc/index.md`.
- Added `aigc/prompts/github-first-ai-ci-delegation-2026-06-05.zh-CN.md`.

## Security
- No runtime security behavior changes.
- The docs explicitly keep security decisions and vulnerability disclosure under maintainer control.

## Release
- Docs-only change; docs deploy remains the normal automatic documentation release path after merge.
