### PR TITLE
ci: add GitHub AI setup workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "area/docs"
       - "type/security"
@@ -11,6 +19,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "area/devops"
       - "type/security"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,32 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,19 @@
 name: (prod) Deploy docs
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
+    paths:
+      - ".dumirc.ts"
+      - ".github/workflows/docs.yml"
+      - "aigc/**"
+      - "docs/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "public/**"
+      - "wrangler.toml"
 
 permissions:
   contents: read
@@ -46,6 +56,9 @@ jobs:
     needs: build
     name: deployment
     environment: prod
+    concurrency:
+      group: cloudflare-docs-prod
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/aigc/README.md
+++ b/aigc/README.md
@@ -14,6 +14,7 @@ here so they survive local multi-git workspace changes and context resets.
 - [Operations backlog](./prompts/open-source-operations-backlog.zh-CN.md)
 - [CI stability incident](./prompts/ci-stability-incident-2026-06-05.zh-CN.md)
 - [Open source ecosystem playbook memory](./prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md)
+- [mss-boot v0.7.2 and admin dependency follow-up](./prompts/mss-boot-v0.7.2-admin-dependency-update-2026-06-05.zh-CN.md)
 
 ## Rules
 

--- a/aigc/prompts/dependency-upgrade-release-v0.7.0-2026-06-05.zh-CN.md
+++ b/aigc/prompts/dependency-upgrade-release-v0.7.0-2026-06-05.zh-CN.md
@@ -1,0 +1,41 @@
+# Dependency Upgrade And v0.7.0 Release
+
+日期：2026-06-05
+
+## 范围
+
+本次处理前后端项目的 Dependabot/deps PR，修复依赖升级暴露的流水线问题，并发布
+`v0.7.0`。
+
+## 前端 mss-boot-admin-antd
+
+- 合并 npm 与 GitHub Actions 依赖升级。
+- 将前端 GitHub Actions Node 基线从 18 调整到 22，用于兼容
+  `cross-env@10` 和 `@cloudflare/kv-asset-handler@0.5.x`。
+- 保持 Cloudflare alpha/beta/prod 发布不随 tag 自动触发。
+- 发布 `v0.7.0`，GitHub Release 产物包含 `dist.tar.gz` 和
+  `dist-local.tar.gz`。
+
+## 后端 mss-boot-admin
+
+- 合并 Go module 与 GitHub Actions 依赖升级，包括 AWS SDK、Kubernetes
+  client-go、Consul、Kafka、OAuth2 等依赖。
+- AWS SDK 相关 PR 在 `go.mod` / `go.sum` 冲突后，按最新 main 重新执行
+  `go get` 与 `go mod tidy`，再交给 GitHub Actions 验证。
+- 发布 `v0.7.0`，后端 release workflow 成功下载前端最新
+  `dist-local.tar.gz` 并打包到后端发布资产。
+
+## 验证
+
+- 前端 main：CI、CodeQL、OpenSSF Scorecard、GitHub Actions Mirror 均通过。
+- 后端 main：CI、CodeQL、govulncheck、Swagger、OpenSSF Scorecard、
+  GitHub Actions Mirror 均通过。
+- 前端 `v0.7.0` tag：Release、Release Draft、Copilot Setup Steps 均通过。
+- 后端 `v0.7.0` tag：Release、CI、Release Draft、Copilot Setup Steps 均通过。
+
+## 经验
+
+- 前端 Cloudflare 发布仍需人工触发；tag release 只负责 GitHub Release 与镜像。
+- 后端 release 依赖前端 latest release，后续发布仍应先发前端，再发后端。
+- 可以优先使用 Dependabot update branch、PR checks 与 GitHub Actions 验证；
+  只有锁文件冲突无法自动解决时，再本地重建分支并强推到对应 Dependabot 分支。

--- a/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
+++ b/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
@@ -1,0 +1,27 @@
+# GitHub Copilot Setup Steps
+
+日期：2026-06-05
+
+## 背景
+
+`mss-boot-docs` 是组织级记忆中心。为了让 GitHub Copilot coding agent 在
+处理文档、记忆、开源治理说明时更快进入可验证状态，需要预热文档项目依赖。
+
+## 已落地
+
+- 新增 `.github/workflows/copilot-setup-steps.yml`。
+- 工作流只在手动触发、或该 workflow 文件变更时运行。
+- 代理环境步骤包括 checkout、`pnpm/action-setup@v6`、
+  `actions/setup-node@v6` 和 `pnpm install --frozen-lockfile`。
+- docs 发布 workflow 增加 `workflow_dispatch`、文档相关 `push.paths` 过滤和
+  `cloudflare-docs-prod` 并发锁，降低无关 main push 触发 Cloudflare 发布的
+  概率。
+- 为 Dependabot 增加 npm minor/patch 分组和 GitHub Actions 分组，降低依赖
+  PR 数量和 CI 噪音。
+
+## 约束
+
+- 该 workflow 只做环境预热，不替代正式 docs CI。
+- 文档站部署继续使用现有 docs workflow；部署触发应限于文档站相关变更或
+  人工触发。
+- 组织级流程、发布策略、社区运营和 AI 记忆必须继续落盘在 docs。

--- a/aigc/prompts/mss-boot-v0.7.2-admin-dependency-update-2026-06-05.zh-CN.md
+++ b/aigc/prompts/mss-boot-v0.7.2-admin-dependency-update-2026-06-05.zh-CN.md
@@ -1,0 +1,55 @@
+# mss-boot v0.7.2 And Admin Dependency Follow-up
+
+日期：2026-06-05
+
+## 范围
+
+本次处理 `mss-boot` 仓库中 deps 类型 PR，发布 `mss-boot v0.7.2`，随后让
+`mss-boot-admin` 升级到该版本，并修复升级过程中暴露的 CI 稳定性问题。
+
+## mss-boot
+
+- 合并 Dependabot/deps PR：
+  - `golang.org/x/crypto` 升级到 `v0.52.0`。
+  - `github.com/hashicorp/consul/api` 升级到 `v1.34.3`。
+  - `github.com/aws/aws-sdk-go-v2/config` 升级到 `v1.32.23`。
+  - `github.com/aws/aws-sdk-go-v2/service/s3` 升级到 `v1.103.2`。
+  - `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc`
+    升级到 `v0.69.0`。
+  - `softprops/action-gh-release` 升级到 `v3`。
+- AWS S3 与 otelgrpc PR 在合并其它依赖后出现 `go.mod` / `go.sum` 冲突，
+  处理方式是基于最新 `origin/main` 重建 Dependabot 分支，重新执行
+  `go get` 与 `go mod tidy`，再强推回对应 Dependabot 分支交给 PR 流水线验证。
+- `main` 全部检查通过后，打 tag 并发布 `v0.7.2`。
+
+## mss-boot-admin
+
+- 新建 `codex/update-mss-boot-v0.7.2-20260605` 分支，将
+  `github.com/mss-boot-io/mss-boot` 从 `v0.7.1` 升级到 `v0.7.2`。
+- `go mod tidy` 同步带入间接依赖升级，包括 grpc、OIDC、Consul、pgx、
+  quic-go、OpenTelemetry 等。
+- PR CI 暴露出 `pkg/gist_test.go` 会访问真实 GitHub Gist API，遇到
+  GitHub API rate limit 时会导致流水线失败。
+- 修复方式：
+  - 在 `pkg/gist.go` 中抽出 `gistClone(ctx, client, id, dir)`，让测试可以注入
+    mock GitHub client。
+  - 移除 `log.Fatal`，改为按错误返回，避免库函数在异常时直接终止进程。
+  - 在 `pkg/gist_test.go` 中使用 `httptest.NewServer` 模拟 Gist API，不再依赖
+    外网 GitHub API 或公开 gist id。
+- PR 验证通过后合并到 `main`。
+
+## 验收口径
+
+- `mss-boot`：Dependabot/deps PR 关闭且 `main` 全绿，`v0.7.2` release workflow
+  通过。
+- `mss-boot-admin`：升级 PR 合并到 `main`，CI、CodeQL、govulncheck、Swagger、
+  OpenSSF Scorecard、GitHub Actions Mirror 等主干检查通过。
+- 两个仓库均不保留打开状态的 Dependabot/deps PR。
+
+## 经验
+
+- deps PR 可以优先交给 Dependabot branch 和 GitHub Actions 自验证；当锁文件冲突
+  无法自动解决时，再本地基于最新主干重建分支。
+- 测试不应依赖 GitHub 等外部实时 API。开源项目的 CI 要优先使用本地 mock、
+  `httptest` 或录制响应，避免受 rate limit、网络、外部服务状态影响。
+- 依赖库函数不应使用 `log.Fatal` 终止进程；应返回错误交给调用方处理。

--- a/docs/aigc/index.md
+++ b/docs/aigc/index.md
@@ -26,6 +26,7 @@ handoffs.
 - [Open source AI-era growth plan](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-ai-era-growth-plan.zh-CN.md)
 - [Open source ecosystem playbook memory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-ecosystem-playbook-2026-06-05.zh-CN.md)
 - [GitHub-first AI and CI delegation](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/github-first-ai-ci-delegation-2026-06-05.zh-CN.md)
+- [GitHub Copilot setup steps](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md)
 - [Good first issue factory](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-good-first-issue-factory.zh-CN.md)
 - [Operations backlog](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-operations-backlog.zh-CN.md)
 - [Community operations execution](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/open-source-community-ops-execution-2026-06-05.zh-CN.md)

--- a/docs/devops/open-source-ecosystem-playbook.md
+++ b/docs/devops/open-source-ecosystem-playbook.md
@@ -89,17 +89,40 @@ or maintainer-only scripts. The default split is:
 | Security alerts | CodeQL code scanning and Copilot Autofix for public repositories | Review generated fixes before merge; never disclose private vulnerability context publicly. |
 | Review assistance | Copilot code review when enabled for the organization | Treat comments as advisory; maintainer remains accountable for acceptance. |
 | Issue drafting | GitHub Copilot issue creation/update and issue forms | Maintainer approves scope, labels, priority, and whether Copilot may be assigned. |
-| Implementation delegation | Copilot coding agent on bounded issues when enabled | Use only for low-to-medium-risk tasks with clear tests and non-goals. |
+| Implementation delegation | Copilot coding agent on bounded issues when enabled, backed by repository instructions and `copilot-setup-steps.yml` | Use only for low-to-medium-risk tasks with clear tests and non-goals. |
 
 Capabilities that are already safe to rely on in public CI should be encoded in
 workflow files. Capabilities that depend on organization policy, Copilot plans,
 GitHub Actions minutes, or security settings must be tracked as pending external
 configuration before use.
 
+Repository-level setup:
+
+- keep `.github/copilot-instructions.md` and `AGENTS.md` in sync so GitHub
+  Copilot and local agents share the same operating boundaries;
+- use `.github/workflows/copilot-setup-steps.yml` to preinstall Go or Node
+  dependencies for Copilot coding agent sessions;
+- group low-risk Dependabot updates where possible and keep explicit open PR
+  limits to avoid overwhelming a personal maintainer;
+- keep frontend Cloudflare deployments manual, and use concurrency locks for
+  public deployment workflows.
+
+Pending maintainer GitHub settings:
+
+- enable or review Copilot automatic code review at the organization or
+  repository level after confirming Actions minutes and Copilot plan impact;
+- configure branch rulesets so stable checks become required checks after the
+  current green CI baseline has held for several days;
+- enable private vulnerability reporting and review whether CodeQL Copilot
+  Autofix should be used for public alerts;
+- decide whether `mss-boot-admin` should inherit organization issue forms or
+  keep backend-specific local issue templates.
+
 Useful GitHub references:
 
 - [Copilot code review](https://docs.github.com/en/copilot/concepts/agents/code-review)
 - [Copilot coding agent](https://docs.github.com/en/copilot/concepts/coding-agent/coding-agent)
+- [Copilot coding agent setup steps](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment)
 - [Copilot issue creation and updates](https://docs.github.com/en/copilot/how-tos/use-copilot-for-common-tasks/use-copilot-to-create-or-update-issues)
 - [Copilot Autofix for code scanning](https://docs.github.com/en/code-security/concepts/code-scanning/copilot-autofix-for-code-scanning)
 


### PR DESCRIPTION
## Summary
- add Copilot coding-agent setup steps for docs dependency prewarming
- add Dependabot grouping and explicit PR limits
- reduce docs Cloudflare deploy noise with push path filters, manual dispatch, and prod concurrency
- document GitHub-first delegation and pending maintainer settings

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'\n- git diff --check\n- pnpm build\n\n## Docs\n- Updates docs/devops/open-source-ecosystem-playbook.md.\n- Updates docs/aigc/index.md and adds repository-local AIGC memory.\n\n## Security\n- Keeps the Copilot setup workflow read-only with contents: read.\n- Does not expose Cloudflare tokens or change secret names.\n- Records maintainer-only GitHub security settings as pending external configuration.\n\n## Release / compatibility / rollback\n- Docs deploy remains automatic only for docs-site-related main changes, plus manual workflow_dispatch.\n- Adds Cloudflare docs deployment concurrency to avoid overlapping prod deploys.\n- Rollback is reverting the docs workflow filter/concurrency if deployment behavior is too restrictive.\n\n## Notes\n- Docs deploy remains automatic only for docs-site-related main changes, plus manual workflow_dispatch.