### PR TITLE
chore: converge docs security dependencies

### DIFF
--- a/aigc/README.md
+++ b/aigc/README.md
@@ -26,6 +26,7 @@ here so they survive local multi-git workspace changes and context resets.
 - [Community triage round](./prompts/community-triage-round-2026-06-09.zh-CN.md)
 - [GitHub security and community health](./prompts/github-security-community-health-2026-06-09.zh-CN.md)
 - [Dependency security governance round](./prompts/dependency-security-governance-round-2026-06-09.zh-CN.md)
+- [Docs dependency security convergence](./prompts/docs-dependency-security-convergence-2026-06-09.zh-CN.md)
 
 ## Rules
 

--- a/aigc/prompts/docs-dependency-security-convergence-2026-06-09.zh-CN.md
+++ b/aigc/prompts/docs-dependency-security-convergence-2026-06-09.zh-CN.md
@@ -1,0 +1,29 @@
+# docs 依赖安全收敛记忆
+
+- 日期：2026-06-09
+- 仓库：mss-boot-docs
+- 背景：docs 仓库 Dependabot alerts 主要来自 dumi/Umi/Vite 文档站工具链。可低风险处理的传递依赖应先收敛，Vite/React Router 等主链路迁移单独评估。
+
+## 本轮处理
+
+- `dumi` 从 `^2.4.28` 升级到 `^2.4.30`，带动 Umi patch 到 4.6.61。
+- 增加 `pnpm.overrides`：
+  - `esbuild@0.25.11`
+  - `nth-check@2.1.1`
+  - `path-to-regexp@1.9.0`
+  - `send@0.19.2`
+  - `uuid@11.1.1`
+
+## 验证
+
+- `CI=true npx -y pnpm@9.15.9 install --frozen-lockfile`
+- `npx -y pnpm@9.15.9 build`
+- `npx -y pnpm@9.15.9 exec prettier --check ...`
+- `npx -y pnpm@9.15.9 audit --json`
+
+## 剩余风险与边界
+
+- `vite` 仍由 `dumi -> umi -> @umijs/bundler-vite` 固定在 4.x，需要 dumi/Umi bundler 专项迁移或上游升级，不能在普通补丁 PR 中强行 override 到 Vite 6/7/8。
+- `react-router` 仍由 Umi 4 链路固定在 6.3.x，需要上游 Umi routing 迁移。
+- `elliptic` 当前 advisory 无 patched version，来自 webpack/node-libs-browser 兼容链路，需等待上游或替换构建链路。
+- `@babel/runtime` advisory 也来自 Umi 主链路，需等待上游 patch 或专项迁移。

--- a/docs/aigc/index.md
+++ b/docs/aigc/index.md
@@ -39,6 +39,7 @@ handoffs.
 - [Community triage round](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/community-triage-round-2026-06-09.zh-CN.md)
 - [GitHub security and community health](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/github-security-community-health-2026-06-09.zh-CN.md)
 - [Dependency security governance round](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/dependency-security-governance-round-2026-06-09.zh-CN.md)
+- [Docs dependency security convergence](https://github.com/mss-boot-io/mss-boot-docs/blob/main/aigc/prompts/docs-dependency-security-convergence-2026-06-09.zh-CN.md)
 
 ## Agent Roles
 

--- a/package.json
+++ b/package.json
@@ -22,10 +22,19 @@
       "prettier --write --no-error-on-unmatched-pattern"
     ]
   },
+  "pnpm": {
+    "overrides": {
+      "esbuild": "0.25.11",
+      "nth-check": "2.1.1",
+      "path-to-regexp": "1.9.0",
+      "send": "0.19.2",
+      "uuid": "11.1.1"
+    }
+  },
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
-    "dumi": "^2.4.28",
+    "dumi": "^2.4.30",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",
     "prettier": "^3.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  esbuild: 0.25.11
+  nth-check: 2.1.1
+  path-to-regexp: 1.9.0
+  send: 0.19.2
+  uuid: 11.1.1
+
 importers:
 
   .:
@@ -15,8 +22,8 @@ importers:
         specifier: ^21.0.2
         version: 21.0.2
       dumi:
-        specifier: ^2.4.28
-        version: 2.4.28(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+        specifier: ^2.4.30
+        version: 2.4.30(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -406,273 +413,159 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
-  '@esbuild/aix-ppc64@0.21.4':
-    resolution: {integrity: sha512-Zrm+B33R4LWPLjDEVnEqt2+SLTATlru1q/xYKVn8oVTbiRBGmK2VIMoIYGJDGyftnGaC788IuzGFAlb7IQ0Y8A==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.25.11':
+    resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.18.20':
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.11':
+    resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.21.4':
-    resolution: {integrity: sha512-fYFnz+ObClJ3dNiITySBUx+oNalYUT18/AryMxfovLkYWbutXsct3Wz2ZWAcGGppp+RVVX5FiXeLYGi97umisA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.18.20':
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.11':
+    resolution: {integrity: sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.21.4':
-    resolution: {integrity: sha512-E7H/yTd8kGQfY4z9t3nRPk/hrhaCajfA3YSQSBrst8B+3uTcgsi8N+ZWYCaeIDsiVs6m65JPCaQN/DxBRclF3A==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.18.20':
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.11':
+    resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.21.4':
-    resolution: {integrity: sha512-mDqmlge3hFbEPbCWxp4fM6hqq7aZfLEHZAKGP9viq9wMUBVQx202aDIfc3l+d2cKhUJM741VrCXEzRFhPDKH3Q==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.18.20':
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.11':
+    resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.21.4':
-    resolution: {integrity: sha512-72eaIrDZDSiWqpmCzVaBD58c8ea8cw/U0fq/PPOTqE3c53D0xVMRt2ooIABZ6/wj99Y+h4ksT/+I+srCDLU9TA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.18.20':
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.11':
+    resolution: {integrity: sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.4':
-    resolution: {integrity: sha512-uBsuwRMehGmw1JC7Vecu/upOjTsMhgahmDkWhGLWxIgUn2x/Y4tIwUZngsmVb6XyPSTXJYS4YiASKPcm9Zitag==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.18.20':
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.11':
+    resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.21.4':
-    resolution: {integrity: sha512-8JfuSC6YMSAEIZIWNL3GtdUT5NhUA/CMUCpZdDRolUXNAXEE/Vbpe6qlGLpfThtY5NwXq8Hi4nJy4YfPh+TwAg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.18.20':
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.11':
+    resolution: {integrity: sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.4':
-    resolution: {integrity: sha512-8d9y9eQhxv4ef7JmXny7591P/PYsDFc4+STaxC1GBv0tMyCdyWfXu2jBuqRsyhY8uL2HU8uPyscgE2KxCY9imQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.18.20':
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.11':
+    resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.21.4':
-    resolution: {integrity: sha512-/GLD2orjNU50v9PcxNpYZi+y8dJ7e7/LhQukN3S4jNDXCKkyyiyAz9zDw3siZ7Eh1tRcnCHAo/WcqKMzmi4eMQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.18.20':
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.11':
+    resolution: {integrity: sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.4':
-    resolution: {integrity: sha512-2rqFFefpYmpMs+FWjkzSgXg5vViocqpq5a1PSRgT0AvSgxoXmGF17qfGAzKedg6wAwyM7UltrKVo9kxaJLMF/g==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.18.20':
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.11':
+    resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.4':
-    resolution: {integrity: sha512-pNftBl7m/tFG3t2m/tSjuYeWIffzwAZT9m08+9DPLizxVOsUl8DdFzn9HvJrTQwe3wvJnwTdl92AonY36w/25g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.18.20':
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.11':
+    resolution: {integrity: sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.4':
-    resolution: {integrity: sha512-cSD2gzCK5LuVX+hszzXQzlWya6c7hilO71L9h4KHwqI4qeqZ57bAtkgcC2YioXjsbfAv4lPn3qe3b00Zt+jIfQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.18.20':
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.11':
+    resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.4':
-    resolution: {integrity: sha512-qtzAd3BJh7UdbiXCrg6npWLYU0YpufsV9XlufKhMhYMJGJCdfX/G6+PNd0+v877X1JG5VmjBLUiFB0o8EUSicA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.18.20':
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.11':
+    resolution: {integrity: sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.4':
-    resolution: {integrity: sha512-yB8AYzOTaL0D5+2a4xEy7OVvbcypvDR05MsB/VVPVA7nL4hc5w5Dyd/ddnayStDgJE59fAgNEOdLhBxjfx5+dg==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.18.20':
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.11':
+    resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.4':
-    resolution: {integrity: sha512-Y5AgOuVzPjQdgU59ramLoqSSiXddu7F3F+LI5hYy/d1UHN7K5oLzYBDZe23QmQJ9PIVUXwOdKJ/jZahPdxzm9w==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.18.20':
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.11':
+    resolution: {integrity: sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.4':
-    resolution: {integrity: sha512-Iqc/l/FFwtt8FoTK9riYv9zQNms7B8u+vAI/rxKuN10HgQIXaPzKZc479lZ0x6+vKVQbu55GdpYpeNWzjOhgbA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.18.20':
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.11':
+    resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.4':
-    resolution: {integrity: sha512-Td9jv782UMAFsuLZINfUpoF5mZIbAj+jv1YVtE58rFtfvoKRiKSkRGQfHTgKamLVT/fO7203bHa3wU122V/Bdg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
+  '@esbuild/netbsd-arm64@0.25.11':
+    resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.18.20':
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-x64@0.25.11':
+    resolution: {integrity: sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.4':
-    resolution: {integrity: sha512-Awn38oSXxsPMQxaV0Ipb7W/gxZtk5Tx3+W+rAPdZkyEhQ6968r9NvtkjhnhbEgWXYbgV+JEONJ6PcdBS+nlcpA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
+  '@esbuild/openbsd-arm64@0.25.11':
+    resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.18.20':
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-x64@0.25.11':
+    resolution: {integrity: sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.4':
-    resolution: {integrity: sha512-IsUmQeCY0aU374R82fxIPu6vkOybWIMc3hVGZ3ChRwL9hA1TwY+tS0lgFWV5+F1+1ssuvvXt3HFqe8roCip8Hg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
+  '@esbuild/openharmony-arm64@0.25.11':
+    resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
 
-  '@esbuild/sunos-x64@0.18.20':
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.25.11':
+    resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.21.4':
-    resolution: {integrity: sha512-hsKhgZ4teLUaDA6FG/QIu2q0rI6I36tZVfM4DBZv3BG0mkMIdEnMbhc4xwLvLJSS22uWmaVkFkqWgIS0gPIm+A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.18.20':
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.11':
+    resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.21.4':
-    resolution: {integrity: sha512-UUfMgMoXPoA/bvGUNfUBFLCh0gt9dxZYIx9W4rfJr7+hKe5jxxHmfOK8YSH4qsHLLN4Ck8JZ+v7Q5fIm1huErg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.18.20':
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.11':
+    resolution: {integrity: sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.4':
-    resolution: {integrity: sha512-yIxbspZb5kGCAHWm8dexALQ9en1IYDfErzjSEq1KzXFniHv019VT3mNtTK7t8qdy4TwT6QYHI9sEZabONHg+aw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.18.20':
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.4':
-    resolution: {integrity: sha512-sywLRD3UK/qRJt0oBwdpYLBibk7KiRfbswmWRDabuncQYSlf8aLEEUor/oP6KRz8KEG+HoiVLBhPRD5JWjS8Sg==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.11':
+    resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -884,42 +777,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -993,36 +893,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -1203,24 +1109,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.9.2':
     resolution: {integrity: sha512-8xzrOmsyCC1zrx2Wzx/h8dVsdewO1oMCwBTLc1gSJ/YllZYTb04pNm6NsVbzUX2tKddJVRgSJXV10j/NECLwpA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.9.2':
     resolution: {integrity: sha512-kZrNz/PjRQKcchWF6W292jk3K44EoVu1ad5w+zbS4jekIAxsM8WwQ1kd+yjUlN9jFcF8XBat5NKIs9WphJCVXg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.9.2':
     resolution: {integrity: sha512-TTIpR4rjMkhX1lnFR+PSXpaL83TrQzp9znRdp2TzYrODlUd/R20zOwSo9vFLCyH6ZoD47bccY7QeGZDYT3nlRg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.9.2':
     resolution: {integrity: sha512-+Eg2d4icItKC0PMjZxH7cSYFLWk0aIp94LNmOw6tPq0e69ax6oh10upeq0D1fjWsKLmOJAWEvnXlayZcijEXDw==}
@@ -1441,38 +1351,38 @@ packages:
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@umijs/ast@4.6.59':
-    resolution: {integrity: sha512-hDZvdWxJ4kY/2J8wapN2sESZW+tgqMm0bxZHTf5PBWwYa+f+Wya/38FLXDZhoAm3YI/YOwvc9mroUzOsZM4Tww==}
+  '@umijs/ast@4.6.61':
+    resolution: {integrity: sha512-dzDMJ2E12Jv2q4/fH6QZ+KxAid1l3RfhcYHG9NOauG0ILZ+77dskqai0xhqN5a4cOMGNcFECjrWEnTMnYLRxOg==}
 
-  '@umijs/babel-preset-umi@4.6.59':
-    resolution: {integrity: sha512-kdTG2buflrdeKWJXjl5gVfC1Yw/eaCTVFl6QcgkfmIKV1M/zNy4G7lGUnxjj8thRLZqpFrtilE/IcBEd2PkUrw==}
+  '@umijs/babel-preset-umi@4.6.61':
+    resolution: {integrity: sha512-ksam2QxwqBf4JqlljQ2JAKOC3dLwJvTnyatg1bHblbIqeazmy2+PLmUDkEj1aDzPj8VvrTubmWdcOMu8YofQBA==}
 
-  '@umijs/bundler-esbuild@4.6.59':
-    resolution: {integrity: sha512-D9lQ2Re6vW+UOqSB9QD7aQLLfJCsqzgYKsiz32tV0GBgfGQoc0pEdNLQvjniBeA0BLOgGMu3ICAynPW0yBivjA==}
+  '@umijs/bundler-esbuild@4.6.61':
+    resolution: {integrity: sha512-1F0xi5Nbx+gJsmlZOVPNhf5Cpxai5lnjMSrgdC57wx3CoFsn7w4tT+bRwOEeJUgMDOUYeke0IBGYRbz02As7Rg==}
     hasBin: true
 
   '@umijs/bundler-mako@0.11.10':
     resolution: {integrity: sha512-RNop0kmMXJUOLQYp61ZW3NVdD8ikOPW0zoCmgkN+nIUVw+QKcA+9tSPEcT6Rr8id9+Ed3lMjLqktev20guRp1g==}
 
-  '@umijs/bundler-utils@4.6.59':
-    resolution: {integrity: sha512-w3fLsyGKhrQ6gCvviksukK0mYsEIMmR4ahVfFehZwl8ORWQrT+moiOj5VJQ1NMvPlrP8pB9E9jtkqMWh74+9vQ==}
+  '@umijs/bundler-utils@4.6.61':
+    resolution: {integrity: sha512-qkPrstpBl1Wt/imG6153PaTfBQ1xSNV03r85QnEX2sAe+8YY9ZS0QmQakDefpp8VuWFkUy+/dqrbtiuF1oMkUg==}
 
-  '@umijs/bundler-utoopack@4.6.59':
-    resolution: {integrity: sha512-3xMmiZwrS3BFarPZRGumgcFouPYS9VB4kuFmVisU86xiVfYtxL+AdqFJ1492iuDBD6P97WRKXSpktbyzxcUzkQ==}
+  '@umijs/bundler-utoopack@4.6.61':
+    resolution: {integrity: sha512-msaX33NMr0lM/tCw6/gCsr4YBkJI6lLJJyPZPlJjHxCeFzIuepo7bcynx5w4U63/QWJrqWlXCkNWQfmMXe0m/w==}
 
-  '@umijs/bundler-vite@4.6.59':
-    resolution: {integrity: sha512-g3W1lZH86632DYFayPtNLdu4WS5T9Yj6TnSyKkgrkviB8pgYbtWcYfn0j3lUUaogeCmswfTPbG7TV5ukZ/9vrA==}
+  '@umijs/bundler-vite@4.6.61':
+    resolution: {integrity: sha512-mzzzJd6NuoHkrCJMLvb8J42WWt/UPWv4Twa8xcUtrdF89CSPORU7E+N2ttZMYZKN88rHAunr3S+lXjSYZ5zczA==}
     hasBin: true
 
-  '@umijs/bundler-webpack@4.6.59':
-    resolution: {integrity: sha512-cRMbg+4pNiws5PA6M3ag+YND77nibrlLmb74/APTXKFWIDg0hzA38s1Zg4NMv+KB8Ur2C8Zq7/FhcvryLr3fnA==}
+  '@umijs/bundler-webpack@4.6.61':
+    resolution: {integrity: sha512-1++MhUC+2sxllhEt7oD4eKM0DsOwu/ZPcqv3151MldKWezwBHpNUyDBQXhykxwFOptAHtbFUY82qNXTdV86sZQ==}
     hasBin: true
 
   '@umijs/case-sensitive-paths-webpack-plugin@1.0.1':
     resolution: {integrity: sha512-kDKJ8yTarxwxGJDInG33hOpaQRZ//XpNuuznQ/1Mscypw6kappzFmrBr2dOYave++K7JHouoANF354UpbEQw0Q==}
 
-  '@umijs/core@4.6.59':
-    resolution: {integrity: sha512-m2xosdAmIHJuw++Svio8zwDtu/fLy+8F9jX3PKPJzywhwlcut5+uGkydoQRzNWfsylSugcj5vIsNtgBwIx0r0w==}
+  '@umijs/core@4.6.61':
+    resolution: {integrity: sha512-/4xkdriM/Nx5UHSk9bjPQpgoWoy2dXT0cdBhedIFmfHKYGdPnpuZV9w93qRhowxyNLf57s/tbxcHz7EYjYYbCw==}
 
   '@umijs/did-you-know@1.0.4':
     resolution: {integrity: sha512-eAHGNRZe9b7nOXINBIWNga/Nh0LWyTILXtFVcEDiJBXhehUi5OtpPHnA18KCgfmsOFxYPt5fzdumHTYQKm92Vw==}
@@ -1500,24 +1410,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/es-module-parser-linux-arm64-musl@0.0.7':
     resolution: {integrity: sha512-cqQffARWkmQ3n1RYNKZR3aD6X8YaP6u1maASjDgPQOpZMAlv/OSDrM/7iGujWTs0PD0haockNG9/DcP6lgPHMw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/es-module-parser-linux-x64-gnu@0.0.7':
     resolution: {integrity: sha512-PHrKHtT665Za0Ydjch4ACrNpRU+WIIden12YyF1CtMdhuLDSoU6UfdhF3NoDbgEUcXVDX/ftOqmj0SbH3R1uew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/es-module-parser-linux-x64-musl@0.0.7':
     resolution: {integrity: sha512-cyZvUK5lcECLWzLp/eU1lFlCETcz+LEb+wrdARQSST1dgoIGZsT4cqM1WzYmdZNk3o883tiZizLt58SieEiHBQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/es-module-parser-win32-arm64-msvc@0.0.7':
     resolution: {integrity: sha512-V7WxnUI88RboSl0RWLNQeKBT7EDW35fW6Tn92zqtoHHxrhAIL9DtDyvC8REP4qTxeZ6Oej/Ax5I6IjsLx3yTOg==}
@@ -1538,8 +1452,8 @@ packages:
   '@umijs/history@5.3.1':
     resolution: {integrity: sha512-/e0cEGrR2bIWQD7pRl3dl9dcyRGeC9hoW0OCvUTT/hjY0EfUrkd6G8ZanVghPMpDuY5usxq9GVcvrT8KNXLWvA==}
 
-  '@umijs/lint@4.6.59':
-    resolution: {integrity: sha512-N9DQbyf66W/vEh179Sn0w3rvbxyYp41V0F5pefCCWl0AyMmWcxh/BWROm5MPZi2LPKTdacciOV2xNaoQzl5Q3Q==}
+  '@umijs/lint@4.6.61':
+    resolution: {integrity: sha512-ayaNS5X8VdsDtlF0YVThtv2SQb3Iyn0bh2qyqwQubxWwQavwC04A8EW+hcnw77gHACwObi2NNlr3avB0f3EVLA==}
 
   '@umijs/mako-darwin-arm64@0.11.10':
     resolution: {integrity: sha512-kCn0mJx2Hq4RIkMNIzMDOdO4JSWq120auFmSEleHkfrFFFqSWX2qgz5mR5VI7kaPH0GUh0+hwfRkjEVGysJGjA==}
@@ -1558,24 +1472,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/mako-linux-arm64-musl@0.11.10':
     resolution: {integrity: sha512-kqI1Jw6IHtDwrcsqPZrYxsV3pHzZyOR+6fCFnF5MSURnXbUbJb6Rk66VsKKpMqbyfsEO6nt0WT9FrRBlFvRU2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/mako-linux-x64-gnu@0.11.10':
     resolution: {integrity: sha512-jlhXVvWJuumMmiE3z3ViugOMx9ZasNM1anng0PsusCgDwfy0IOfGzfwfwagqtzfsC5MwyRcfnRQyDdbfbroaSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/mako-linux-x64-musl@0.11.10':
     resolution: {integrity: sha512-SLV/PRdL12dFEKlQGenW3OboZXmdYi25y+JblgVJLBhpdxZrHFqpCsTZn4L3hVEhyl0/ksR1iY0wtfK3urR29g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/mako-win32-ia32-msvc@0.11.10':
     resolution: {integrity: sha512-quCWpVl7yQjG+ccGhkF81GxO3orXdPW1OZWXWxJgOI0uPk7Hczh2EYMEVqqQGbi/83eJ1e3iE1jRTl/+2eHryQ==}
@@ -1594,14 +1512,14 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
 
-  '@umijs/mfsu@4.6.59':
-    resolution: {integrity: sha512-mDRncGJcwS/uLxka92a7ZLz42IshQMHAmhXdty7IKqYigMgpSvv/z0g6aSh69Uqghizda6gb5pCqc3j3Tjk9Lw==}
+  '@umijs/mfsu@4.6.61':
+    resolution: {integrity: sha512-bhpVHKlCHazKpH8Y3/srNj71tGV0xyqT0n1f/b+SKW4ZoqDNpax8GIMQlzC8AoD7F1AOm6gLT6UnGS28EilL8A==}
 
-  '@umijs/plugin-run@4.6.59':
-    resolution: {integrity: sha512-A1yTvcqT+vEyPHO+RQBabVcHMe4zc/NzqvRXVjTW0F9rSYaaISFDW+T5zbTrPqFWYVzs+21fuxlYbASybpuWGQ==}
+  '@umijs/plugin-run@4.6.61':
+    resolution: {integrity: sha512-3/cV7PZLnNxR/DQy8LSSo+gE3uT9SyO+jmvGGbYwo89Vi4dnedayEO7iISh40bZuEpRuwUfua7hq+ntKNdlP5w==}
 
-  '@umijs/preset-umi@4.6.59':
-    resolution: {integrity: sha512-Zxk+i4A1RzBlDWy9tQGeEWMZ2xkmvOHLed2BmdJvaaOlMesQwygkcsSXLOIfciEb3Kf5YMuIMLLNUUwfpmmAeA==}
+  '@umijs/preset-umi@4.6.61':
+    resolution: {integrity: sha512-OZmTN7QKvPYG7hMmir9acEfFoyPRgBclKkoIa0CQl8dWbh10IlXnQpa4+1yyzobpICP5SqVhluUCbv6dLNF4bw==}
 
   '@umijs/react-refresh-webpack-plugin@0.5.11':
     resolution: {integrity: sha512-RtFvB+/GmjRhpHcqNgnw8iWZpTlxOnmNxi8eDcecxMmxmSgeDj25LV0jr4Q6rOhv3GTIfVGBhkwz+khGT5tfmg==}
@@ -1629,78 +1547,82 @@ packages:
       webpack-plugin-serve:
         optional: true
 
-  '@umijs/renderer-react@4.6.59':
-    resolution: {integrity: sha512-ZoKJoUe6TMhr6tqSGgelosT5jIonbTrISewJQNIVNVBQkSOWbCo4BLs+7apRbtVXqbMBbWZWmpg8sWVQFHI+Ng==}
+  '@umijs/renderer-react@4.6.61':
+    resolution: {integrity: sha512-5Ycogrz+IBlCp4eekm8WxiqHyHwuQeF/ItTNVfjoIjJLGELOyZDh3du2SPPWkFMHg23xEVMbG8RfgQ6wdzKhjA==}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@umijs/server@4.6.59':
-    resolution: {integrity: sha512-kZlwKdldwgUPyu/aQa4j7vtcERq4LUlaIDIplBKcDrGZfyNc8Aix53N/3rzwpjVYGphz2GkM6XjUljMtNRK6iQ==}
+  '@umijs/server@4.6.61':
+    resolution: {integrity: sha512-boLGY79wBKqYnAY8X681jGTci7pNe5VwsbW+crEKt31MAkJTAGcDT9IVW10CRQ7N1/mvJ8FYysEw0Ghgozefkg==}
 
-  '@umijs/test@4.6.59':
-    resolution: {integrity: sha512-4oiybIZcmW0UZdlFZYFCdUk/7LKoIQBOpTuzgDKChGFKMX1ADWwqI643vmBKchPzso2et0DEwaVD/yMUgOnA3w==}
+  '@umijs/test@4.6.61':
+    resolution: {integrity: sha512-mIjgh/XRFFrTkDnQZeTLKZzU7eLHcMDAyRkLHP2w71bd0PX3gQovr6TPxUVAa9cASv7KNbxqJ+tHBTBXBSFI/g==}
 
   '@umijs/ui@3.0.1':
     resolution: {integrity: sha512-zcz37AJH0xt/6XVVbyO/hmsK9Hq4vH23HZ4KYVi5A8rbM9KeJkJigTS7ELOdArawZhVNGe+h3a5Oixs4a2QsWw==}
 
-  '@umijs/utils@4.6.59':
-    resolution: {integrity: sha512-CFkqgduHbLQhzXZe2npJ4PtZbaAtP8a1dRpSw9wCZ4SQfupgrOhqeFXI0LVomhCnbgRr+wolWFLhmHIZwq4gNw==}
+  '@umijs/utils@4.6.61':
+    resolution: {integrity: sha512-WUaIlSwcMuQnCBn5v8TOOHquWVkxcXiit1hOUq5jI8bpWXoSpkldy7/uUaT6jW95txgdghMRGWwI7EvGDaOLXg==}
 
-  '@umijs/zod2ts@4.6.59':
-    resolution: {integrity: sha512-21Ciud+Bpw94hH4kRAlqqhu0F+rj1W0NgZBIfVz+1T1/5eEbQIuZMclYy8mQV2MrBMyrWEcHkEXJcxXrxK+gwQ==}
+  '@umijs/zod2ts@4.6.61':
+    resolution: {integrity: sha512-DYp64/ZC0BlclmLL2+5FLRiaLPmcusv69c/EGxqYLWi0O4Edod5IxCVdtfrecAOI9sYhPAtrArJywi+ZeeXXeA==}
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@utoo/pack-darwin-arm64@1.4.11':
-    resolution: {integrity: sha512-xBEL22D+PbyxtiyLWisHkt3mv+nD+vSkNXR9l2ZbtE8jIPYSd8oXYjr9JYUhL7WkvT7cHZ+r60u+Y5HEqx0l2g==}
+  '@utoo/pack-darwin-arm64@1.4.12':
+    resolution: {integrity: sha512-02tZBShCSyPjnnmh4a2b7CS3YlrJZhGLSfEiFsUg3StZGSJXCgUHlpgcg+1105cNc77OrPFbwMdi+qhJTtwjJQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@utoo/pack-darwin-x64@1.4.11':
-    resolution: {integrity: sha512-1cfoXE+GvVym9AOexD41NCX6V4ugCvAwVb5ENTWZqY+MCDCJgzdCjFRfLtfti7vpyRczbuX5FphfoDhZg3hadg==}
+  '@utoo/pack-darwin-x64@1.4.12':
+    resolution: {integrity: sha512-On0zerp4EBpiu5tvHvzm+oKhYIIKOZPbD1GKyCgOrdcHY82mDw58LaGflBAVerkiFfxmR8sxUc2b8B4BFRhC1Q==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@utoo/pack-linux-arm64-gnu@1.4.11':
-    resolution: {integrity: sha512-Er/uu9UJOPKfrGtFZwa1SQsa+o+GIkD9lytwySIrcoxBm1gtlTveDSyj7D4Dg/cY3nVmMGoQhhluN+iPW71qMw==}
+  '@utoo/pack-linux-arm64-gnu@1.4.12':
+    resolution: {integrity: sha512-xDf9IsgHJHuGA17x1To4WrjkpwbYzlnAWj1OusmtZ/1e6ekM8FUN1kEkORGWth8hGmNaA3vaSqYs7pUgQEMcaw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@utoo/pack-linux-arm64-musl@1.4.11':
-    resolution: {integrity: sha512-L1FBkudER1XMiYIbFXt+icNTQnERsLQx2fliPeu0NbwQ6KT0CwzAPjFjp8prWpxXmK5Z0jV3tQX+11bedRJOIA==}
+  '@utoo/pack-linux-arm64-musl@1.4.12':
+    resolution: {integrity: sha512-gRk9WJ2bb407FsNz06aPaafv91aJRRfSQ9PsAbHViRF2P0Bs9T9ZpmHVH3SBsebVeT1NdY+j1jUE7vJYw0PFhw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@utoo/pack-linux-x64-gnu@1.4.11':
-    resolution: {integrity: sha512-foUYC6qmYeRZQOLw/nWlC6R9IkNvQ2tIVbKzD8stxl817JJUpS6KtFggEanUEPzYuQRuMDu96wQF5DWlCfrfLA==}
+  '@utoo/pack-linux-x64-gnu@1.4.12':
+    resolution: {integrity: sha512-G85pEaWhooK0jvjPI0jysJ9n9DwEEQ7x9vgeHqDUF0oTbOtDw0xNIb1YvbLl6zVI7gJObV9kghFdmEgvTuVL9A==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@utoo/pack-linux-x64-musl@1.4.11':
-    resolution: {integrity: sha512-XN2Ml+oPpd8uOqmXs+N8hQAS+0MHY8WEm6cWjbhmyDSKE+TEgNwz7kHSs6HjeS1I8bzwLLxFz0x1oW0qkbPF4w==}
+  '@utoo/pack-linux-x64-musl@1.4.12':
+    resolution: {integrity: sha512-XFeqWXN6aPH5LP2Nbmtyu+lZ3KZHJ2qzt3ykTGfMf+NEkGxqzeTaTgz/v0K5ZyXXB1ueDTkLElKlvVqD7tQQsQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@utoo/pack-shared@1.4.11':
-    resolution: {integrity: sha512-9e7qMoNGDiVbPxq4Mf3KAZvQbA5H0s0Tme7bMUBDm+ynAdfZMKfzGg4FEIZNHzF81LWJXxHNgUVnWxBNjnN2cg==}
+  '@utoo/pack-shared@1.4.12':
+    resolution: {integrity: sha512-9wFLkCjBg4mPF7pr/S7voSy7bPX1L0Fkav8vqTjwp7CBPHElLkVJk81Sc7LU6i8+N3KnoI8esNsxnIWgLBQ9Ug==}
     engines: {node: '>= 20'}
 
-  '@utoo/pack-win32-x64-msvc@1.4.11':
-    resolution: {integrity: sha512-37evJkMY+NmRdu5Uw/cXfreUQar2mJMYdj/n10+vojecqZB4eoeZyHKFbOXi6hypJgztDc0cv2NWAwAyVin53A==}
+  '@utoo/pack-win32-x64-msvc@1.4.12':
+    resolution: {integrity: sha512-Fy/EHb5qlIKZCFLPCJ8LbEEU+TNm6Wvl5lTzsTvvFtFH5QHC/sr3IOwKVAnki3AaqlpCaMYWOoyXb3T4jdFfmQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@utoo/pack@1.4.11':
-    resolution: {integrity: sha512-mGon1CR6yem/aV0mjmW7/h+o9JaU3QIq86kMwH5txLex+SJ/8FdtzXLkRX8dpAteLMox0U3RVDHOkMR5J6s8Hg==}
+  '@utoo/pack@1.4.12':
+    resolution: {integrity: sha512-dN0Sq7+Tp7ct9D5r+ULBp9IYdwj67yNsMW725mW4fURCf0QkPK6G15QEF/UKf1fsx37FehEjs+0mznznFUtTUw==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -2561,10 +2483,6 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  depd@1.1.2:
-    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
-    engines: {node: '>= 0.6'}
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -2575,9 +2493,6 @@ packages:
 
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
-
-  destroy@1.0.4:
-    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -2669,24 +2584,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   domparser-linux-arm64-musl@0.0.7:
     resolution: {integrity: sha512-dV14s5WwfotBFGrp5SCGLk0J6LCAj+ZcuuLmpQOsbekPCbiZksk7XOoE2RrZ03ny+/bWN+Sh+jaU9IGiryMVxQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   domparser-linux-x64-gnu@0.0.7:
     resolution: {integrity: sha512-Ugu95+nsEyWgEsZ0v6cDp9rUHong0HeWMbjmzjICNIvAdbXfaCjbSk+m10YeOTk2N3O4svLvwfnCLYbRcvUTTg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   domparser-linux-x64-musl@0.0.7:
     resolution: {integrity: sha512-ssuCW0QL1ZB7MjOL0F5o06uy6qreaRsiA8EIGl5rfQstoWrQeKWEtI0yh7dIxvN++Zz0GLFY9IdbSj8GUuY4Kg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   domparser-rs@0.0.7:
     resolution: {integrity: sha512-OGXsNHyFLGHGzi/zdPRw+Nv4jQdh7DCgmJAQYHXTIGXX1nW4RFwPyocv+VvemRHqs2QFOH6MDhpkzhiXiI6caA==}
@@ -2726,8 +2645,8 @@ packages:
   dumi-assets-types@2.4.14:
     resolution: {integrity: sha512-k2Z3z7/IcHOYASP/nDjocShdzXatmOuhkAwgYw/4KNiq36gpAKjn5MlrPkzdGH70TbcHGLGEul9b/4sYJLoS9A==}
 
-  dumi@2.4.28:
-    resolution: {integrity: sha512-kut8XD8Gey/5+XXyi9rwo65n0zPtVqDeKATQLxOoCyxwmM259VaA1vOe83lgSgV9t+UKmDqweE1cCZCdDHFj1w==}
+  dumi@2.4.30:
+    resolution: {integrity: sha512-1tbbJQC8V6WvCxTxizbSF/3Kgr/xdeWCfkzKDi/8G7QvjhaWKVAAcA8kV+R6FmPPD4klBaKSkl1XSgthxiFtOg==}
     hasBin: true
     peerDependencies:
       react: '>=16.8'
@@ -2768,10 +2687,6 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
-
-  encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2871,14 +2786,9 @@ packages:
   es6-promise@4.2.8:
     resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
 
-  esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.21.4:
-    resolution: {integrity: sha512-sFMcNNrj+Q0ZDolrp5pDhH0nRPN9hLIM3fRPwgbLYJeSHHgnXSnbV3xYgSVuOeLWH9c73VwmEverVzupIv5xuA==}
-    engines: {node: '>=12'}
+  esbuild@0.25.11:
+    resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.2.0:
@@ -3477,10 +3387,6 @@ packages:
   http-deceiver@1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}
 
-  http-errors@1.7.3:
-    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
-    engines: {node: '>= 0.6'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -4020,24 +3926,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.22.1:
     resolution: {integrity: sha512-MCV6RuRpzXbunvzwY644iz8cw4oQxvW7oer9xPkdadYqlEyiJJ6wl7FyJOH7Q6ZYH4yjGAUCvxDBxPbnDu9ZVg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.22.1:
     resolution: {integrity: sha512-RjNgpdM20VUXgV7us/VmlO3Vn2ZRiDnc3/bUxCVvySZWPiVPprpqW/QDWuzkGa+NCUf6saAM5CLsZLSxncXJwg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.22.1:
     resolution: {integrity: sha512-ZgO4C7Rd6Hv/5MnyY2KxOYmIlzk4rplVolDt3NbkNR8DndnyX0Q5IR4acJWNTBICQ21j3zySzKbcJaiJpk/4YA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.22.1:
     resolution: {integrity: sha512-4pozV4eyD0MDET41ZLHAeBo+H04Nm2UEYIk5w/ts40231dRFV7E0cjwbnZvSoc1DXFgecAhiC0L16ruv/ZDCpg==}
@@ -4410,9 +4320,6 @@ packages:
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
-  ms@2.1.1:
-    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -4503,9 +4410,6 @@ packages:
   nprogress@0.2.0:
     resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
-  nth-check@1.0.2:
-    resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -4558,10 +4462,6 @@ packages:
 
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
-
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -4695,11 +4595,8 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@0.1.13:
-    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
-
-  path-to-regexp@1.7.0:
-    resolution: {integrity: sha512-nifX1uj4S9IrK/w3Xe7kKvNEepXivANs9ng60Iq7PU/BlouV3yL/VUhFqTuTq33ykwUqoNcTeGo5vdOBP4jS/Q==}
+  path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -5592,10 +5489,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.17.1:
-    resolution: {integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==}
-    engines: {node: '>= 0.8.0'}
-
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -5618,9 +5511,6 @@ packages:
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
-
-  setprototypeof@1.1.1:
-    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -5764,10 +5654,6 @@ packages:
 
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  statuses@1.5.0:
-    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
-    engines: {node: '>= 0.6'}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -6061,10 +5947,6 @@ packages:
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
-  toidentifier@1.0.0:
-    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
-    engines: {node: '>=0.6'}
-
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -6159,8 +6041,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  umi@4.6.59:
-    resolution: {integrity: sha512-YmkeIqsb1pNc7AC5JkQBXo5kP8cohZBp5L5QtRXsEcP4vBxSk/uvQaIgmI06M1/lmvOfkU5U+I4OC4tHL5l8bg==}
+  umi@4.6.61:
+    resolution: {integrity: sha512-fqIMRMFi+VnKiq9lcCHzpKCX5ffR5PeW/Ta7SCcYsiGBRcoUd8q+Pm+aDSagq1R+OYl9y4gaze69N2hgPl3kNg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6267,9 +6149,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uvu@0.5.6:
@@ -6957,7 +6838,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.25.11
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -6965,139 +6846,82 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.14.0
 
-  '@esbuild/aix-ppc64@0.21.4':
+  '@esbuild/aix-ppc64@0.25.11':
     optional: true
 
-  '@esbuild/android-arm64@0.18.20':
+  '@esbuild/android-arm64@0.25.11':
     optional: true
 
-  '@esbuild/android-arm64@0.21.4':
+  '@esbuild/android-arm@0.25.11':
     optional: true
 
-  '@esbuild/android-arm@0.18.20':
+  '@esbuild/android-x64@0.25.11':
     optional: true
 
-  '@esbuild/android-arm@0.21.4':
+  '@esbuild/darwin-arm64@0.25.11':
     optional: true
 
-  '@esbuild/android-x64@0.18.20':
+  '@esbuild/darwin-x64@0.25.11':
     optional: true
 
-  '@esbuild/android-x64@0.21.4':
+  '@esbuild/freebsd-arm64@0.25.11':
     optional: true
 
-  '@esbuild/darwin-arm64@0.18.20':
+  '@esbuild/freebsd-x64@0.25.11':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.4':
+  '@esbuild/linux-arm64@0.25.11':
     optional: true
 
-  '@esbuild/darwin-x64@0.18.20':
+  '@esbuild/linux-arm@0.25.11':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.4':
+  '@esbuild/linux-ia32@0.25.11':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.18.20':
+  '@esbuild/linux-loong64@0.25.11':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.4':
+  '@esbuild/linux-mips64el@0.25.11':
     optional: true
 
-  '@esbuild/freebsd-x64@0.18.20':
+  '@esbuild/linux-ppc64@0.25.11':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.4':
+  '@esbuild/linux-riscv64@0.25.11':
     optional: true
 
-  '@esbuild/linux-arm64@0.18.20':
+  '@esbuild/linux-s390x@0.25.11':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.4':
+  '@esbuild/linux-x64@0.25.11':
     optional: true
 
-  '@esbuild/linux-arm@0.18.20':
+  '@esbuild/netbsd-arm64@0.25.11':
     optional: true
 
-  '@esbuild/linux-arm@0.21.4':
+  '@esbuild/netbsd-x64@0.25.11':
     optional: true
 
-  '@esbuild/linux-ia32@0.18.20':
+  '@esbuild/openbsd-arm64@0.25.11':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.4':
+  '@esbuild/openbsd-x64@0.25.11':
     optional: true
 
-  '@esbuild/linux-loong64@0.18.20':
+  '@esbuild/openharmony-arm64@0.25.11':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.4':
+  '@esbuild/sunos-x64@0.25.11':
     optional: true
 
-  '@esbuild/linux-mips64el@0.18.20':
+  '@esbuild/win32-arm64@0.25.11':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.4':
+  '@esbuild/win32-ia32@0.25.11':
     optional: true
 
-  '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.4':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.21.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.18.20':
-    optional: true
-
-  '@esbuild/linux-s390x@0.21.4':
-    optional: true
-
-  '@esbuild/linux-x64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.4':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.21.4':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.4':
-    optional: true
-
-  '@esbuild/sunos-x64@0.18.20':
-    optional: true
-
-  '@esbuild/sunos-x64@0.21.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.18.20':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.4':
-    optional: true
-
-  '@esbuild/win32-ia32@0.18.20':
-    optional: true
-
-  '@esbuild/win32-ia32@0.21.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.18.20':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.4':
+  '@esbuild/win32-x64@0.25.11':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
@@ -7315,7 +7139,7 @@ snapshots:
 
   '@loadable/component@5.15.2(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
       react-is: 16.13.1
@@ -7558,7 +7382,7 @@ snapshots:
 
   '@stylelint/postcss-css-in-js@0.38.0(postcss-syntax@0.36.2(postcss@8.5.15))(postcss@8.5.15)':
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.29.7
       postcss: 8.5.15
       postcss-syntax: 0.36.2(postcss@8.5.15)
     transitivePeerDependencies:
@@ -7819,7 +7643,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 17.0.45
+      '@types/node': 25.9.2
 
   '@types/semver@7.7.1': {}
 
@@ -7923,26 +7747,26 @@ snapshots:
       '@typescript-eslint/types': 5.62.0
       eslint-visitor-keys: 3.4.3
 
-  '@umijs/ast@4.6.59':
+  '@umijs/ast@4.6.61':
     dependencies:
-      '@umijs/bundler-utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/babel-preset-umi@4.6.59':
+  '@umijs/babel-preset-umi@4.6.61':
     dependencies:
       '@babel/runtime': 7.23.6
       '@bloomberg/record-tuple-polyfill': 0.0.4
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/utils': 4.6.61
       core-js: 3.34.0
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/bundler-esbuild@4.6.59':
+  '@umijs/bundler-esbuild@4.6.61':
     dependencies:
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/utils': 4.6.61
       enhanced-resolve: 5.9.3
       postcss: 8.5.15
       postcss-flexbugs-fixes: 5.0.2(postcss@8.5.15)
@@ -7952,7 +7776,7 @@ snapshots:
 
   '@umijs/bundler-mako@0.11.10(postcss@8.5.15)(sass@1.100.0)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
-      '@umijs/bundler-utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
       '@umijs/mako': 0.11.10(postcss@8.5.15)(sass@1.100.0)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       chalk: 4.1.2
       compression: 1.8.1
@@ -7974,21 +7798,21 @@ snapshots:
       - typescript
       - webpack
 
-  '@umijs/bundler-utils@4.6.59':
+  '@umijs/bundler-utils@4.6.61':
     dependencies:
-      '@umijs/utils': 4.6.59
-      esbuild: 0.21.4
+      '@umijs/utils': 4.6.61
+      esbuild: 0.25.11
       regenerate: 1.4.2
       regenerate-unicode-properties: 10.1.1
       spdy: 4.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/bundler-utoopack@4.6.59(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/bundler-utoopack@4.6.61(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/bundler-webpack': 4.6.59(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@utoo/pack': 1.4.11(less-loader@11.1.0(less@4.1.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      '@utoo/pack': 1.4.12(less-loader@11.1.0(less@4.1.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
       cors: 2.8.6
@@ -7999,7 +7823,7 @@ snapshots:
       postcss: 8.5.15
       resolve-url-loader: 5.0.0
       sass: 1.54.0
-      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      sass-loader: 13.2.0(sass@1.100.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@types/webpack'
       - bufferutil
@@ -8017,18 +7841,18 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@umijs/bundler-vite@4.6.59(@types/node@25.9.2)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)':
+  '@umijs/bundler-vite@4.6.61(@types/node@25.9.2)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)':
     dependencies:
       '@svgr/core': 6.5.1
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/utils': 4.6.61
       '@vitejs/plugin-react': 4.0.0(vite@4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0))
       core-js: 3.34.0
       less: 4.1.3
       postcss-preset-env: 7.5.0(postcss@8.5.15)
       rollup-plugin-visualizer: 5.9.0(rollup@3.30.0)
       systemjs: 6.15.1
-      vite: 4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.48.0)
+      vite: 4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)
     transitivePeerDependencies:
       - '@types/node'
       - lightningcss
@@ -8040,18 +7864,18 @@ snapshots:
       - supports-color
       - terser
 
-  '@umijs/bundler-webpack@4.6.59(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/bundler-webpack@4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
       '@svgr/plugin-svgo': 6.5.1(@svgr/core@6.5.1)
       '@types/hapi__joi': 17.1.9
-      '@umijs/babel-preset-umi': 4.6.59
-      '@umijs/bundler-utils': 4.6.59
+      '@umijs/babel-preset-umi': 4.6.61
+      '@umijs/bundler-utils': 4.6.61
       '@umijs/case-sensitive-paths-webpack-plugin': 1.0.1
-      '@umijs/mfsu': 4.6.59
+      '@umijs/mfsu': 4.6.61
       '@umijs/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@0.20.2)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/utils': 4.6.59
+      '@umijs/utils': 4.6.61
       cors: 2.8.6
       css-loader: 6.7.1(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       es5-imcompatible-versions: 0.1.90
@@ -8076,10 +7900,10 @@ snapshots:
 
   '@umijs/case-sensitive-paths-webpack-plugin@1.0.1': {}
 
-  '@umijs/core@4.6.59':
+  '@umijs/core@4.6.61':
     dependencies:
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/utils': 4.6.61
     transitivePeerDependencies:
       - supports-color
 
@@ -8126,17 +7950,17 @@ snapshots:
 
   '@umijs/history@5.3.1':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
       query-string: 6.14.1
 
-  '@umijs/lint@4.6.59(eslint@8.57.1)(stylelint@14.16.1)(typescript@5.9.3)':
+  '@umijs/lint@4.6.61(eslint@8.57.1)(stylelint@14.16.1)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/eslint-parser': 7.23.3(@babel/core@7.23.6)(eslint@8.57.1)
       '@stylelint/postcss-css-in-js': 0.38.0(postcss-syntax@0.36.2(postcss@8.5.15))(postcss@8.5.15)
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
-      '@umijs/babel-preset-umi': 4.6.59
+      '@umijs/babel-preset-umi': 4.6.61
       eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       eslint-plugin-react: 7.33.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.1)
@@ -8218,44 +8042,44 @@ snapshots:
       - typescript
       - webpack
 
-  '@umijs/mfsu@4.6.59':
+  '@umijs/mfsu@4.6.61':
     dependencies:
-      '@umijs/bundler-esbuild': 4.6.59
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-esbuild': 4.6.61
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/utils': 4.6.61
       enhanced-resolve: 5.9.3
       is-equal: 1.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/plugin-run@4.6.59':
+  '@umijs/plugin-run@4.6.61':
     dependencies:
       tsx: 3.12.2
 
-  '@umijs/preset-umi@4.6.59(@types/node@25.9.2)(@types/react@19.2.17)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/preset-umi@4.6.61(@types/node@25.9.2)(@types/react@19.2.17)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@iconify/utils': 2.1.1
       '@stagewise/toolbar': 0.6.2
       '@svgr/core': 6.5.1
-      '@umijs/ast': 4.6.59
-      '@umijs/babel-preset-umi': 4.6.59
-      '@umijs/bundler-esbuild': 4.6.59
+      '@umijs/ast': 4.6.61
+      '@umijs/babel-preset-umi': 4.6.61
+      '@umijs/bundler-esbuild': 4.6.61
       '@umijs/bundler-mako': 0.11.10(postcss@8.5.15)(sass@1.100.0)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/bundler-utoopack': 4.6.59(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/bundler-vite': 4.6.59(@types/node@25.9.2)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)
-      '@umijs/bundler-webpack': 4.6.59(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/core': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/bundler-utoopack': 4.6.61(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/bundler-vite': 4.6.61(@types/node@25.9.2)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/core': 4.6.61
       '@umijs/did-you-know': 1.0.4
       '@umijs/es-module-parser': 0.0.7
       '@umijs/history': 5.3.1
-      '@umijs/mfsu': 4.6.59
-      '@umijs/plugin-run': 4.6.59
-      '@umijs/renderer-react': 4.6.59(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@umijs/server': 4.6.59
+      '@umijs/mfsu': 4.6.61
+      '@umijs/plugin-run': 4.6.61
+      '@umijs/renderer-react': 4.6.61(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@umijs/server': 4.6.61
       '@umijs/ui': 3.0.1
-      '@umijs/utils': 4.6.59
-      '@umijs/zod2ts': 4.6.59
+      '@umijs/utils': 4.6.61
+      '@umijs/zod2ts': 4.6.61
       babel-plugin-dynamic-import-node: 2.3.3
       babel-plugin-react-compiler: 0.0.0-experimental-c23de8d-20240515
       click-to-react-component: 1.1.3(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8265,7 +8089,7 @@ snapshots:
       fast-glob: 3.2.12
       html-webpack-plugin: 5.5.0(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       less-plugin-resolve: 1.0.2
-      path-to-regexp: 1.7.0
+      path-to-regexp: 1.9.0
       postcss: 8.5.15
       postcss-prefix-selector: 1.16.0(postcss@8.5.15)
       react: 18.3.1
@@ -8315,7 +8139,7 @@ snapshots:
     optionalDependencies:
       type-fest: 0.20.2
 
-  '@umijs/renderer-react@4.6.59(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@umijs/renderer-react@4.6.61(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.23.6
       '@loadable/component': 5.15.2(react@18.3.1)
@@ -8325,9 +8149,9 @@ snapshots:
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@umijs/server@4.6.59':
+  '@umijs/server@4.6.61':
     dependencies:
-      '@umijs/bundler-utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8335,14 +8159,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/test@4.6.59(@babel/core@7.29.7)':
+  '@umijs/test@4.6.61(@babel/core@7.29.7)':
     dependencies:
       '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.29.7)
       '@jest/types': 27.5.1
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/utils': 4.6.61
       babel-jest: 29.7.0(@babel/core@7.29.7)
-      esbuild: 0.21.4
+      esbuild: 0.25.11
       identity-obj-proxy: 3.0.0
       isomorphic-unfetch: 4.0.2
     transitivePeerDependencies:
@@ -8351,48 +8175,48 @@ snapshots:
 
   '@umijs/ui@3.0.1': {}
 
-  '@umijs/utils@4.6.59':
+  '@umijs/utils@4.6.61':
     dependencies:
       chokidar: 3.5.3
       pino: 7.11.0
 
-  '@umijs/zod2ts@4.6.59': {}
+  '@umijs/zod2ts@4.6.61': {}
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@utoo/pack-darwin-arm64@1.4.11':
+  '@utoo/pack-darwin-arm64@1.4.12':
     optional: true
 
-  '@utoo/pack-darwin-x64@1.4.11':
+  '@utoo/pack-darwin-x64@1.4.12':
     optional: true
 
-  '@utoo/pack-linux-arm64-gnu@1.4.11':
+  '@utoo/pack-linux-arm64-gnu@1.4.12':
     optional: true
 
-  '@utoo/pack-linux-arm64-musl@1.4.11':
+  '@utoo/pack-linux-arm64-musl@1.4.12':
     optional: true
 
-  '@utoo/pack-linux-x64-gnu@1.4.11':
+  '@utoo/pack-linux-x64-gnu@1.4.12':
     optional: true
 
-  '@utoo/pack-linux-x64-musl@1.4.11':
+  '@utoo/pack-linux-x64-musl@1.4.12':
     optional: true
 
-  '@utoo/pack-shared@1.4.11':
+  '@utoo/pack-shared@1.4.12':
     dependencies:
       '@babel/code-frame': 7.22.5
       picocolors: 1.1.1
 
-  '@utoo/pack-win32-x64-msvc@1.4.11':
+  '@utoo/pack-win32-x64-msvc@1.4.12':
     optional: true
 
-  '@utoo/pack@1.4.11(less-loader@11.1.0(less@4.1.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))':
+  '@utoo/pack@1.4.12(less-loader@11.1.0(less@4.1.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))':
     dependencies:
       '@babel/code-frame': 7.22.5
       '@hono/node-server': 1.19.14(hono@4.12.23)
       '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.23))(hono@4.12.23)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.11
+      '@utoo/pack-shared': 1.4.12
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -8404,19 +8228,19 @@ snapshots:
       postcss: 8.5.15
       resolve-url-loader: 5.0.0
       sass: 1.54.0
-      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      sass-loader: 13.2.0(sass@1.100.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       semver: 7.8.2
-      send: 0.17.1
+      send: 0.19.2
       styled-jsx: 5.1.7(@babel/core@7.29.7)(react@18.3.1)
       ws: 8.21.0
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.11
-      '@utoo/pack-darwin-x64': 1.4.11
-      '@utoo/pack-linux-arm64-gnu': 1.4.11
-      '@utoo/pack-linux-arm64-musl': 1.4.11
-      '@utoo/pack-linux-x64-gnu': 1.4.11
-      '@utoo/pack-linux-x64-musl': 1.4.11
-      '@utoo/pack-win32-x64-msvc': 1.4.11
+      '@utoo/pack-darwin-arm64': 1.4.12
+      '@utoo/pack-darwin-x64': 1.4.12
+      '@utoo/pack-linux-arm64-gnu': 1.4.12
+      '@utoo/pack-linux-arm64-musl': 1.4.12
+      '@utoo/pack-linux-x64-gnu': 1.4.12
+      '@utoo/pack-linux-x64-musl': 1.4.12
+      '@utoo/pack-win32-x64-msvc': 1.4.12
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8428,7 +8252,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
       react-refresh: 0.14.2
-      vite: 4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.48.0)
+      vite: 4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9284,7 +9108,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 3.4.2
       domutils: 1.7.0
-      nth-check: 1.0.2
+      nth-check: 2.1.1
 
   css-select@4.3.0:
     dependencies:
@@ -9412,8 +9236,6 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  depd@1.1.2: {}
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -9422,8 +9244,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-
-  destroy@1.0.4: {}
 
   destroy@1.2.0: {}
 
@@ -9558,7 +9378,7 @@ snapshots:
 
   dumi-assets-types@2.4.14: {}
 
-  dumi@2.4.28(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
+  dumi@2.4.30(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@ant-design/icons-svg': 4.4.2
       '@makotot/ghostui': 2.0.0(react@18.3.1)
@@ -9566,9 +9386,9 @@ snapshots:
       '@swc/core': 1.9.2(@swc/helpers@0.5.15)
       '@types/hast': 2.3.10
       '@types/mdast': 3.0.15
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/core': 4.6.59
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/core': 4.6.61
+      '@umijs/utils': 4.6.61
       animated-scroll-to: 2.3.2
       classnames: 2.3.2
       codesandbox-import-utils: 2.2.3
@@ -9623,7 +9443,7 @@ snapshots:
       sass: 1.100.0
       sitemap: 7.1.3
       sucrase: 3.35.1
-      umi: 4.6.59(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      umi: 4.6.61(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       unified: 10.1.2
       unist-util-visit: 4.1.2
       unist-util-visit-parents: 5.1.3
@@ -9709,8 +9529,6 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
-
-  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -9876,56 +9694,34 @@ snapshots:
 
   es6-promise@4.2.8: {}
 
-  esbuild@0.18.20:
+  esbuild@0.25.11:
     optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
-
-  esbuild@0.21.4:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.4
-      '@esbuild/android-arm': 0.21.4
-      '@esbuild/android-arm64': 0.21.4
-      '@esbuild/android-x64': 0.21.4
-      '@esbuild/darwin-arm64': 0.21.4
-      '@esbuild/darwin-x64': 0.21.4
-      '@esbuild/freebsd-arm64': 0.21.4
-      '@esbuild/freebsd-x64': 0.21.4
-      '@esbuild/linux-arm': 0.21.4
-      '@esbuild/linux-arm64': 0.21.4
-      '@esbuild/linux-ia32': 0.21.4
-      '@esbuild/linux-loong64': 0.21.4
-      '@esbuild/linux-mips64el': 0.21.4
-      '@esbuild/linux-ppc64': 0.21.4
-      '@esbuild/linux-riscv64': 0.21.4
-      '@esbuild/linux-s390x': 0.21.4
-      '@esbuild/linux-x64': 0.21.4
-      '@esbuild/netbsd-x64': 0.21.4
-      '@esbuild/openbsd-x64': 0.21.4
-      '@esbuild/sunos-x64': 0.21.4
-      '@esbuild/win32-arm64': 0.21.4
-      '@esbuild/win32-ia32': 0.21.4
-      '@esbuild/win32-x64': 0.21.4
+      '@esbuild/aix-ppc64': 0.25.11
+      '@esbuild/android-arm': 0.25.11
+      '@esbuild/android-arm64': 0.25.11
+      '@esbuild/android-x64': 0.25.11
+      '@esbuild/darwin-arm64': 0.25.11
+      '@esbuild/darwin-x64': 0.25.11
+      '@esbuild/freebsd-arm64': 0.25.11
+      '@esbuild/freebsd-x64': 0.25.11
+      '@esbuild/linux-arm': 0.25.11
+      '@esbuild/linux-arm64': 0.25.11
+      '@esbuild/linux-ia32': 0.25.11
+      '@esbuild/linux-loong64': 0.25.11
+      '@esbuild/linux-mips64el': 0.25.11
+      '@esbuild/linux-ppc64': 0.25.11
+      '@esbuild/linux-riscv64': 0.25.11
+      '@esbuild/linux-s390x': 0.25.11
+      '@esbuild/linux-x64': 0.25.11
+      '@esbuild/netbsd-arm64': 0.25.11
+      '@esbuild/netbsd-x64': 0.25.11
+      '@esbuild/openbsd-arm64': 0.25.11
+      '@esbuild/openbsd-x64': 0.25.11
+      '@esbuild/openharmony-arm64': 0.25.11
+      '@esbuild/sunos-x64': 0.25.11
+      '@esbuild/win32-arm64': 0.25.11
+      '@esbuild/win32-ia32': 0.25.11
+      '@esbuild/win32-x64': 0.25.11
 
   escalade@3.2.0: {}
 
@@ -10135,7 +9931,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.13
+      path-to-regexp: 1.9.0
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
@@ -10634,7 +10430,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -10709,7 +10505,7 @@ snapshots:
       svgo-browser: 1.3.8
       svgson: 4.1.0
       transformation-matrix: 2.16.1
-      uuid: 8.3.2
+      uuid: 11.1.1
 
   htmlparser2@6.1.0:
     dependencies:
@@ -10726,14 +10522,6 @@ snapshots:
       entities: 4.5.0
 
   http-deceiver@1.2.7: {}
-
-  http-errors@1.7.3:
-    dependencies:
-      depd: 1.1.2
-      inherits: 2.0.4
-      setprototypeof: 1.1.1
-      statuses: 1.5.0
-      toidentifier: 1.0.0
 
   http-errors@2.0.1:
     dependencies:
@@ -11388,7 +11176,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.0.5
+      hash-base: 3.1.2
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
@@ -11836,8 +11624,6 @@ snapshots:
 
   ms@2.0.0: {}
 
-  ms@2.1.1: {}
-
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -11971,10 +11757,6 @@ snapshots:
 
   nprogress@0.2.0: {}
 
-  nth-check@1.0.2:
-    dependencies:
-      boolbase: 1.0.0
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -12047,10 +11829,6 @@ snapshots:
       unset-value: 0.1.2
 
   on-exit-leak-free@0.2.0: {}
-
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
 
   on-finished@2.4.1:
     dependencies:
@@ -12197,9 +11975,7 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-to-regexp@0.1.13: {}
-
-  path-to-regexp@1.7.0:
+  path-to-regexp@1.9.0:
     dependencies:
       isarray: 0.0.1
 
@@ -12750,7 +12526,7 @@ snapshots:
 
   react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -13066,13 +12842,13 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.2.0(sass@1.54.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
+  sass-loader@13.2.0(sass@1.100.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
       webpack: 5.105.4(lightningcss@1.22.1)(postcss@8.5.15)
     optionalDependencies:
-      sass: 1.54.0
+      sass: 1.100.0
 
   sass-loader@16.0.8(sass@1.100.0)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
@@ -13128,24 +12904,6 @@ snapshots:
 
   semver@7.8.2: {}
 
-  send@0.17.1:
-    dependencies:
-      debug: 2.6.9
-      depd: 1.1.2
-      destroy: 1.0.4
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 1.7.3
-      mime: 1.6.0
-      ms: 2.1.1
-      on-finished: 2.3.0
-      range-parser: 1.2.1
-      statuses: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
-
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -13196,8 +12954,6 @@ snapshots:
       es-object-atoms: 1.1.2
 
   setimmediate@1.0.5: {}
-
-  setprototypeof@1.1.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -13357,8 +13113,6 @@ snapshots:
   stable@0.1.8: {}
 
   stackframe@1.3.4: {}
-
-  statuses@1.5.0: {}
 
   statuses@2.0.2: {}
 
@@ -13701,8 +13455,6 @@ snapshots:
 
   toggle-selection@1.0.6: {}
 
-  toidentifier@1.0.0: {}
-
   toidentifier@1.0.1: {}
 
   transformation-matrix@2.16.1: {}
@@ -13794,18 +13546,18 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  umi@4.6.59(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
+  umi@4.6.61(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@babel/runtime': 7.23.6
-      '@umijs/bundler-utils': 4.6.59
-      '@umijs/bundler-webpack': 4.6.59(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/core': 4.6.59
-      '@umijs/lint': 4.6.59(eslint@8.57.1)(stylelint@14.16.1)(typescript@5.9.3)
-      '@umijs/preset-umi': 4.6.59(@types/node@25.9.2)(@types/react@19.2.17)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/renderer-react': 4.6.59(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@umijs/server': 4.6.59
-      '@umijs/test': 4.6.59(@babel/core@7.29.7)
-      '@umijs/utils': 4.6.59
+      '@umijs/bundler-utils': 4.6.61
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/core': 4.6.61
+      '@umijs/lint': 4.6.61(eslint@8.57.1)(stylelint@14.16.1)(typescript@5.9.3)
+      '@umijs/preset-umi': 4.6.61(@types/node@25.9.2)(@types/react@19.2.17)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/renderer-react': 4.6.61(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@umijs/server': 4.6.61
+      '@umijs/test': 4.6.61(@babel/core@7.29.7)
+      '@umijs/utils': 4.6.61
       prettier-plugin-organize-imports: 3.2.4(prettier@3.8.3)(typescript@5.9.3)
       prettier-plugin-packagejson: 2.4.3(prettier@3.8.3)
     transitivePeerDependencies:
@@ -13968,7 +13720,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   uvu@0.5.6:
     dependencies:
@@ -14005,9 +13757,9 @@ snapshots:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  vite@4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.48.0):
+  vite@4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0):
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.25.11
       postcss: 8.5.15
       rollup: 3.30.0
     optionalDependencies:
@@ -14015,7 +13767,7 @@ snapshots:
       fsevents: 2.3.3
       less: 4.1.3
       lightningcss: 1.22.1
-      sass: 1.54.0
+      sass: 1.100.0
       terser: 5.48.0
 
   vm-browserify@1.1.2: {}


### PR DESCRIPTION
## Summary

This PR performs a low-risk dependency security convergence pass for the documentation site.

It:

- updates `dumi` from `^2.4.28` to `^2.4.30`, bringing the Umi toolchain to the latest patch line available in this branch
- adds `pnpm.overrides` for patchable transitive dependencies: `esbuild@0.25.11`, `nth-check@2.1.1`, `path-to-regexp@1.9.0`, `send@0.19.2`, and `uuid@11.1.1`
- records the decision boundary in `aigc/prompts/docs-dependency-security-convergence-2026-06-09.zh-CN.md`

## Security Notes

This reduces the patchable documentation-site dependency surface while keeping the dumi/Umi integration stable.

The remaining Vite and React Router alerts are tied to the dumi/Umi bundler and router chain. They should be handled through an upstream-compatible dumi/Umi migration rather than a broad major-version override in this PR.

## Documentation Impact

The AIGC memory/docs index is updated so maintainers can see what was fixed in this pass and which dependency alerts are intentionally deferred to a migration track.

## Verification

- `CI=true npx -y pnpm@9.15.9 install --frozen-lockfile`
- `npx -y pnpm@9.15.9 build`
- `npx -y pnpm@9.15.9 exec prettier --check ...`
- `git diff --check`
- `npx -y pnpm@9.15.9 audit --json`

## Release Notes

This is a docs-site dependency update only. It does not change backend APIs or the admin Cloudflare release flow.
