### PR TITLE
chore: pin docs toolchain security deps

### DIFF
--- a/aigc/prompts/docs-security-alert-convergence-2026-06-11.zh-CN.md
+++ b/aigc/prompts/docs-security-alert-convergence-2026-06-11.zh-CN.md
@@ -1,0 +1,46 @@
+# docs 安全依赖收敛记忆 2026-06-11
+
+## 背景
+
+- 仓库：`mss-boot-io/mss-boot-docs`
+- 触发来源：社区运营 heartbeat 巡检发现 docs 仓库仍有 15 个 open Dependabot alerts。
+- 主要风险集中在 dumi -> Umi 4 工具链：
+  - `vite@4.5.2`
+  - `react-router@6.3.0`
+  - `@babel/runtime@7.23.6`
+  - `elliptic@6.6.1`
+
+## 本轮处理
+
+- 新建分支：`codex/fix-docs-vite-router-alerts-20260611`
+- 修改 `package.json` 的 `pnpm.overrides`：
+  - `@babel/runtime` -> `7.29.7`
+  - `@vitejs/plugin-react@4.0.0` -> `4.7.0`
+  - `react-router@6.3.0` -> `6.30.4`
+  - `react-router-dom@6.3.0` -> `6.30.4`
+  - `vite@4.5.2` -> `6.4.3`
+- 更新 `pnpm-lock.yaml`，保持 lockfileVersion `9.0`，与 CI 的 pnpm 9 兼容。
+
+## 验证结果
+
+- `CI=true corepack pnpm@9.15.9 install --frozen-lockfile` 通过。
+- `CI=true corepack pnpm@9.15.9 build` 通过。
+- `corepack pnpm@9.15.9 audit --audit-level=moderate` 通过，输出只剩 1 个 low vulnerability。
+- `pnpm why` 确认：
+  - `vite` 解析到 `6.4.3`
+  - `react-router` 解析到 `6.30.4`
+  - `react-router-dom` 解析到 `6.30.4`
+  - `@vitejs/plugin-react` 解析到 `4.7.0`
+  - `@babel/runtime` 只剩 `7.29.7`
+
+## 剩余问题
+
+- `elliptic@6.6.1` 仍有 low alert，GitHub Dependabot advisory 显示 `first_patched_version=null`。
+- 该依赖来自 `crypto-browserify` / `node-libs-browser` / Umi bundler webpack 兼容链路，不能通过普通 patch version 解决。
+- 后续如需清零，需要评估 docs 工具链是否可以移除相关 webpack/node polyfill 兼容链，或等待上游替代方案。
+
+## 开源治理口径
+
+- 本轮是安全依赖收敛 PR，不改变公开文档内容和发布策略。
+- docs deploy 只能在 GitHub checks 通过后由 main workflow 正常触发。
+- 对外说明应强调：大部分 docs 安全告警已收敛，剩余 low alert 无上游 patched version，需要单独迁移评估。

--- a/package.json
+++ b/package.json
@@ -24,11 +24,16 @@
   },
   "pnpm": {
     "overrides": {
+      "@babel/runtime": "7.29.7",
+      "@vitejs/plugin-react@4.0.0": "4.7.0",
       "esbuild": "0.25.11",
       "nth-check": "2.1.1",
       "path-to-regexp": "1.9.0",
+      "react-router@6.3.0": "6.30.4",
+      "react-router-dom@6.3.0": "6.30.4",
       "send": "0.19.2",
-      "uuid": "11.1.1"
+      "uuid": "11.1.1",
+      "vite@4.5.2": "6.4.3"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,16 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@babel/runtime': 7.29.7
+  '@vitejs/plugin-react@4.0.0': 4.7.0
   esbuild: 0.25.11
   nth-check: 2.1.1
   path-to-regexp: 1.9.0
+  react-router@6.3.0: 6.30.4
+  react-router-dom@6.3.0: 6.30.4
   send: 0.19.2
   uuid: 11.1.1
+  vite@4.5.2: 6.4.3
 
 importers:
 
@@ -23,7 +28,7 @@ importers:
         version: 21.0.2
       dumi:
         specifier: ^2.4.30
-        version: 2.4.30(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+        version: 2.4.30(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))(yaml@2.9.0)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -230,10 +235,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.23.6':
-    resolution: {integrity: sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -981,6 +982,151 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
+    engines: {node: '>=14.0.0'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
+
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
@@ -1633,11 +1779,11 @@ packages:
       sass-loader: ^13.2.0
       styled-jsx: ^5.1.6
 
-  '@vitejs/plugin-react@4.0.0':
-    resolution: {integrity: sha512-HX0XzMjL3hhOYm+0s95pb0Z7F8O81G7joUHgfDd/9J/ZZf5k4xX6QAMFkKsHFxaHlf6X7GD7+XuaZ66ULiJuhQ==}
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0
+      vite: 6.4.3
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -5179,14 +5325,20 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.3.0:
-    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-router-dom@6.30.4:
+    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.3.0:
-    resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}
+  react-router@6.30.4:
+    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
+    engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
 
@@ -5244,9 +5396,6 @@ packages:
 
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-
-  regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regex-parser@2.3.1:
     resolution: {integrity: sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==}
@@ -5364,6 +5513,11 @@ packages:
   rollup@3.30.0:
     resolution: {integrity: sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   run-applescript@5.0.0:
@@ -6180,20 +6334,26 @@ packages:
   vfile@5.3.7:
     resolution: {integrity: sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==}
 
-  vite@4.5.2:
-    resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': '>= 14'
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
+      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -6201,11 +6361,17 @@ packages:
         optional: true
       sass:
         optional: true
+      sass-embedded:
+        optional: true
       stylus:
         optional: true
       sugarss:
         optional: true
       terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   vm-browserify@1.1.2:
@@ -6626,10 +6792,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/runtime@7.23.6':
-    dependencies:
-      regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.29.7': {}
 
@@ -7361,6 +7523,85 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@remix-run/router@1.23.3': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
+
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
       domhandler: 5.0.3
@@ -7755,7 +7996,7 @@ snapshots:
 
   '@umijs/babel-preset-umi@4.6.61':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
       '@bloomberg/record-tuple-polyfill': 0.0.4
       '@umijs/bundler-utils': 4.6.61
       '@umijs/utils': 4.6.61
@@ -7841,28 +8082,32 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@umijs/bundler-vite@4.6.61(@types/node@25.9.2)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)':
+  '@umijs/bundler-vite@4.6.61(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)':
     dependencies:
       '@svgr/core': 6.5.1
       '@umijs/bundler-utils': 4.6.61
       '@umijs/utils': 4.6.61
-      '@vitejs/plugin-react': 4.0.0(vite@4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0))
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.3(@types/node@25.9.2)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       core-js: 3.34.0
       less: 4.1.3
       postcss-preset-env: 7.5.0(postcss@8.5.15)
       rollup-plugin-visualizer: 5.9.0(rollup@3.30.0)
       systemjs: 6.15.1
-      vite: 4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)
+      vite: 6.4.3(@types/node@25.9.2)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - lightningcss
       - postcss
       - rollup
       - sass
+      - sass-embedded
       - stylus
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
   '@umijs/bundler-webpack@4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
@@ -8056,7 +8301,7 @@ snapshots:
     dependencies:
       tsx: 3.12.2
 
-  '@umijs/preset-umi@4.6.61(@types/node@25.9.2)(@types/react@19.2.17)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/preset-umi@4.6.61(@types/node@25.9.2)(@types/react@19.2.17)(jiti@2.7.0)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))(yaml@2.9.0)':
     dependencies:
       '@iconify/utils': 2.1.1
       '@stagewise/toolbar': 0.6.2
@@ -8067,7 +8312,7 @@ snapshots:
       '@umijs/bundler-mako': 0.11.10(postcss@8.5.15)(sass@1.100.0)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/bundler-utils': 4.6.61
       '@umijs/bundler-utoopack': 4.6.61(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
-      '@umijs/bundler-vite': 4.6.61(@types/node@25.9.2)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)
+      '@umijs/bundler-vite': 4.6.61(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       '@umijs/bundler-webpack': 4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/core': 4.6.61
       '@umijs/did-you-know': 1.0.4
@@ -8094,8 +8339,8 @@ snapshots:
       postcss-prefix-selector: 1.16.0(postcss@8.5.15)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.3.0(react@18.3.1)
-      react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
+      react-router-dom: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - '@rspack/core'
@@ -8104,6 +8349,7 @@ snapshots:
       - '@types/webpack'
       - bufferutil
       - fibers
+      - jiti
       - lightningcss
       - node-sass
       - rollup
@@ -8115,6 +8361,7 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - type-fest
       - typescript
       - utf-8-validate
@@ -8122,6 +8369,7 @@ snapshots:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
+      - yaml
 
   '@umijs/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@0.20.2)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
@@ -8141,13 +8389,13 @@ snapshots:
 
   '@umijs/renderer-react@4.6.61(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
       '@loadable/component': 5.15.2(react@18.3.1)
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   '@umijs/server@4.6.61':
     dependencies:
@@ -8155,7 +8403,7 @@ snapshots:
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router-dom: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8246,13 +8494,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@vitejs/plugin-react@4.0.0(vite@4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.9.2)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
-      react-refresh: 0.14.2
-      vite: 4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@25.9.2)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9378,7 +9628,7 @@ snapshots:
 
   dumi-assets-types@2.4.14: {}
 
-  dumi@2.4.30(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
+  dumi@2.4.30(@babel/core@7.29.7)(@swc/helpers@0.5.15)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))(yaml@2.9.0):
     dependencies:
       '@ant-design/icons-svg': 4.4.2
       '@makotot/ghostui': 2.0.0(react@18.3.1)
@@ -9443,7 +9693,7 @@ snapshots:
       sass: 1.100.0
       sitemap: 7.1.3
       sucrase: 3.35.1
-      umi: 4.6.61(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      umi: 4.6.61(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))(yaml@2.9.0)
       unified: 10.1.2
       unist-util-visit: 4.1.2
       unist-util-visit-parents: 5.1.3
@@ -9463,6 +9713,7 @@ snapshots:
       - eslint
       - fibers
       - jest
+      - jiti
       - lightningcss
       - node-sass
       - postcss-html
@@ -9480,6 +9731,7 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - type-fest
       - typescript
       - utf-8-validate
@@ -9487,6 +9739,7 @@ snapshots:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
+      - yaml
 
   dunder-proto@1.0.1:
     dependencies:
@@ -12562,16 +12815,18 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      history: 5.3.0
+      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.3.0(react@18.3.1)
+      react-router: 6.30.4(react@18.3.1)
 
-  react-router@6.3.0(react@18.3.1):
+  react-router@6.30.4(react@18.3.1):
     dependencies:
-      history: 5.3.0
+      '@remix-run/router': 1.23.3
       react: 18.3.1
 
   react-simple-code-editor@0.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -12643,8 +12898,6 @@ snapshots:
   regenerate@1.4.2: {}
 
   regenerator-runtime@0.13.11: {}
-
-  regenerator-runtime@0.14.1: {}
 
   regex-parser@2.3.1: {}
 
@@ -12801,6 +13054,38 @@ snapshots:
 
   rollup@3.30.0:
     optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
+
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
   run-applescript@5.0.0:
@@ -13546,14 +13831,14 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  umi@4.6.61(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15)):
+  umi@4.6.61(@babel/core@7.29.7)(@types/node@25.9.2)(@types/react@19.2.17)(eslint@8.57.1)(jiti@2.7.0)(lightningcss@1.22.1)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(stylelint@14.16.1)(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))(yaml@2.9.0):
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.7
       '@umijs/bundler-utils': 4.6.61
       '@umijs/bundler-webpack': 4.6.61(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/core': 4.6.61
       '@umijs/lint': 4.6.61(eslint@8.57.1)(stylelint@14.16.1)(typescript@5.9.3)
-      '@umijs/preset-umi': 4.6.61(@types/node@25.9.2)(@types/react@19.2.17)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/preset-umi': 4.6.61(@types/node@25.9.2)(@types/react@19.2.17)(jiti@2.7.0)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.100.0)(styled-jsx@5.1.7(@babel/core@7.29.7)(react@18.3.1))(terser@5.48.0)(type-fest@0.20.2)(typescript@5.9.3)(webpack@5.105.4(lightningcss@1.22.1)(postcss@8.5.15))(yaml@2.9.0)
       '@umijs/renderer-react': 4.6.61(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@umijs/server': 4.6.61
       '@umijs/test': 4.6.61(@babel/core@7.29.7)
@@ -13572,6 +13857,7 @@ snapshots:
       - eslint
       - fibers
       - jest
+      - jiti
       - lightningcss
       - node-sass
       - postcss-html
@@ -13592,6 +13878,7 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
       - type-fest
       - typescript
       - utf-8-validate
@@ -13599,6 +13886,7 @@ snapshots:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
+      - yaml
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -13757,18 +14045,23 @@ snapshots:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
-  vite@4.5.2(@types/node@25.9.2)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0):
+  vite@6.4.3(@types/node@25.9.2)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.11
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.15
-      rollup: 3.30.0
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.2
       fsevents: 2.3.3
+      jiti: 2.7.0
       less: 4.1.3
       lightningcss: 1.22.1
       sass: 1.100.0
       terser: 5.48.0
+      yaml: 2.9.0
 
   vm-browserify@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- pin the dumi/Umi Vite toolchain from Vite 4.5.2 to Vite 6.4.3 through @vitejs/plugin-react 4.7.0
- pin React Router 6.x to 6.30.4
- pin @babel/runtime to 7.29.7
- record the dependency convergence in aigc memory

## Security impact
This targets the open docs Dependabot alerts for Vite and React Router, and the pnpm audit alert for @babel/runtime. Local audit with pnpm 9 now reports only one low severity advisory for elliptic, which has no patched version in the GitHub advisory.

## Docs impact
No public docs content is changed. The durable AI memory was added under aigc so future agents keep the dependency and remaining elliptic context.

## Tests impact
No unit tests are changed because this repository validates the docs site primarily through dependency installation and dumi build. The CI-equivalent install and build commands both passed locally with pnpm 9.

## Release and compatibility impact
The docs build still passes with the same CI package manager version, pnpm 9. This PR should flow through the normal docs CI and deploy checks after merge.

## Validation
- CI=true corepack pnpm@9.15.9 install --frozen-lockfile
- CI=true corepack pnpm@9.15.9 build
- corepack pnpm@9.15.9 audit --audit-level=moderate
- pnpm why vite react-router react-router-dom @vitejs/plugin-react @babel/runtime elliptic

## Remaining risk
elliptic@6.6.1 still has a low severity advisory with no patched version. It comes through the crypto-browserify/node-libs-browser/Umi bundler compatibility chain and should be handled as a separate toolchain migration decision.