### PR TITLE
docs(aigc): record PR review governance round

### DIFF
--- a/aigc/prompts/pr-review-governance-round-2026-06-13.zh-CN.md
+++ b/aigc/prompts/pr-review-governance-round-2026-06-13.zh-CN.md
@@ -60,6 +60,27 @@
 - 依赖类 PR 已 approve，若仓库策略允许，可按常规 squash merge；如要批量合并，注意先确认 main 分支最新 CI。
 - docs 的 `#35` 与 `#36` 有 lockfile overlap，建议先合并安全收敛 PR，再让 Prettier PR rebase；或者反向操作，但必须保证最终 lockfile 来自同一次 `pnpm install --frozen-lockfile` 可验证状态。
 
+## 2026-06-14 复核更新
+
+- `mss-boot-admin#396`
+  - 作者已补 `20260614120000_repair_user_sessions.go`，使用新的唯一 13 位迁移前缀 `2026061412000` 对 `models.UserSession` 执行幂等 `AutoMigrate`。
+  - 该方案覆盖了此前指出的现有数据库升级路径：即便旧库已经记录 `2026060716205`，也会通过新的 repair migration 补建 `mss_boot_user_sessions`。
+  - PR body 已补 Security / Docs / Release impact，`aigc/prompts/migration-version-collision-repair-2026-06-14.zh-CN.md` 已记录根因和兼容策略。
+  - GitHub CI、CodeQL、govulncheck、PR Guard、Docs Drift 全绿。
+  - 本地复核：`go test ./cmd/migrate/migration/system` 通过；迁移文件 13 位前缀扫描无新增碰撞。
+  - 已执行：approve，并移除 `release-blocker` / `queue/feedback` 标签。
+
+- `mss-boot-admin-antd#114`
+  - 作者已补 Tests / Docs / Security / Release impact，并将 `Closes #94` 改为 `Follow-up to #94`。
+  - GitHub CI、CodeQL、PR Guard、Docs Drift 全绿。
+  - 代码层面仍维持上轮判断：drawer loading/error、i18n key、表格布局修复方向正确，未改变后端 API/权限契约。
+  - 已执行：approve，并移除 `queue/feedback` 标签。
+
+- 合并策略
+  - 本轮只 review/approve，没有 merge。
+  - 原因：用户本轮指令是“PR 有更新了，看下”；前端仓库仍需注意不要把 main 合并与 Cloudflare 发布节奏混在一起。
+  - 如果后续明确进入合并阶段，社区 PR 按 squash merge；前端上线仍遵守“本地/预发验证通过后再发 Cloudflare”的节奏。
+
 ## 社区互动口径
 
 - 对外部贡献者先肯定方向，再明确阻塞点，避免把流程问题说成代码否定。

--- a/aigc/prompts/pr-review-governance-round-2026-06-13.zh-CN.md
+++ b/aigc/prompts/pr-review-governance-round-2026-06-13.zh-CN.md
@@ -1,0 +1,67 @@
+# PR review 治理轮次记忆 2026-06-13
+
+## 背景
+
+- 范围：`mss-boot-io/mss-boot`、`mss-boot-admin`、`mss-boot-admin-antd`、`mss-boot-docs` 四个核心开源仓库。
+- 目标：按开源项目标准复核 open PR，评估技术正确性、项目方向一致性，并给出社区互动回复。
+- 执行账号：`lwnmengjing`。
+
+## 本轮结论
+
+### mss-boot
+
+- 当前无 open PR。
+- 最近 PR 均已合并，本轮无需互动。
+
+### mss-boot-admin
+
+- `#396 fix(migrate): resolve migration issues for SQLite and MySQL compatibility`
+  - 作者：`12ain`。
+  - 方向判断：方向正确，`migration.GetFilename()` 只取文件名前 13 位，旧的 `20260607162057` 与 `20260607162058` 确实会碰撞。
+  - 技术阻塞：PR 只修复新库；对已经跑过旧碰撞迁移的库，版本 `2026060716205` 可能已被旧的菜单迁移记录，导致 `user_sessions` 建表迁移继续被跳过。
+  - 已执行互动：提交 `request changes`，要求补一个后续唯一版本号的幂等修复迁移，确保现有库也能创建 `mss_boot_user_sessions`。
+  - 流水线状态：CI、CodeQL、govulncheck 通过；PR Guard 与 Docs Drift 失败。
+  - 治理标签：`area/backend`、`type/bug`、`release-blocker`、`queue/feedback`。
+  - 后续动作：等待作者补修复迁移、补 `aigc` 或文档记忆、补 PR body 的 Security/Docs/Release 影响说明。
+
+- `#391`、`#392`、`#393`、`#394`、`#395` Dependabot 依赖升级
+  - 范围：`go.mod` / `go.sum` 级别的 Go 依赖升级。
+  - 技术判断：CI、CodeQL、govulncheck、PR Guard、Docs Drift 均通过。
+  - 兼容判断：项目已使用 Go 1.26，`pyroscope-go` 上游 Go >= 1.24 支持下限可接受。
+  - 已执行互动：分别 approve，并说明是依赖维护、范围受控、方向一致。
+
+### mss-boot-admin-antd
+
+- `#114 fix(online-session): drawer loading, i18n key, button text`
+  - 作者：`12ain`。
+  - 方向判断：方向正确，聚焦在线会话页面的 loading、i18n、按钮文案和表格布局体验，符合当前产品迭代方向。
+  - 技术判断：此前 review 指出的双重错误 UI、空错误消息、双 tooltip、死 key、双重类型断言、loading 残留等问题已基本修复。
+  - 剩余问题：PR Guard 失败，主要是 PR body 缺少 Tests、Docs、Security、Release/Compatibility 影响说明；`Closes #94` 更像引用旧 PR，应改为 `Follow-up to #94`，除非确实要关闭一个 issue。
+  - 已执行互动：提交非阻塞 review comment，说明代码方向可接受，需补 PR 元数据后再进入合并判断。
+  - 治理标签：`area/frontend`、`type/bug`、`queue/feedback`。
+
+### mss-boot-docs
+
+- `#36 chore(deps-dev): bump prettier from 3.8.3 to 3.8.4`
+  - 作者：Dependabot。
+  - 技术判断：Prettier patch 升级，CI、CodeQL、PR Guard、Docs Drift 均通过。
+  - 已执行互动：approve。
+
+- `#35 chore: pin docs toolchain security deps`
+  - 作者：`lwnmengjing`。
+  - 技术判断：方向正确，用 `pnpm.overrides` 收敛 Vite、React Router、`@babel/runtime` 等 docs 工具链安全告警，并已记录 `aigc` 记忆。
+  - 已执行互动：因同一维护者身份无法作为外部 review approve，已评论说明技术上可接受，并提醒与 `#36` 同时修改 lockfile，后合并者需 rebase。
+  - 治理标签：`area/docs`、`type/security`、`queue/review`。
+
+## 后续工作建议
+
+- 优先处理 `mss-boot-admin#396`：这是 release blocker，需要补现有数据库升级路径。
+- `mss-boot-admin-antd#114` 可以在作者补 PR body 后重新跑 guard，再做最终 approve/merge 判断。
+- 依赖类 PR 已 approve，若仓库策略允许，可按常规 squash merge；如要批量合并，注意先确认 main 分支最新 CI。
+- docs 的 `#35` 与 `#36` 有 lockfile overlap，建议先合并安全收敛 PR，再让 Prettier PR rebase；或者反向操作，但必须保证最终 lockfile 来自同一次 `pnpm install --frozen-lockfile` 可验证状态。
+
+## 社区互动口径
+
+- 对外部贡献者先肯定方向，再明确阻塞点，避免把流程问题说成代码否定。
+- 对迁移、部署、配置类变更必须要求 `aigc` 或文档记忆，因为这是组织级 AI 协作的持久上下文。
+- 对 Dependabot PR 可以在 CI 全绿、范围受控时快速 approve，保持仓库维护节奏和社区可见度。


### PR DESCRIPTION
## Summary

- record the 2026-06-13 PR review governance round for the four core repositories
- capture the technical/directional decisions for community PRs, Dependabot PRs, and docs security PRs
- document follow-up actions without including environment secrets or deployment credentials

## Tests

- Not run; documentation memory only.

## Docs

- Adds durable AI memory under `aigc/prompts/`.

## Security

- No secrets, kubeconfig, tokens, DSNs, or credentials are included.

## Release / compatibility

- No public docs runtime behavior changes.
