### PR TITLE
docs(aigc): add community update post draft

### DIFF
--- a/aigc/prompts/community-update-post-2026-06-14.zh-CN.md
+++ b/aigc/prompts/community-update-post-2026-06-14.zh-CN.md
@@ -21,6 +21,10 @@
 - GitHub 站内内容可以继续按维护者授权节奏推进。
 - CSDN、知乎、X、LinkedIn、Reddit、掘金等外部平台发布前，需要维护者在操作当次确认平台与账号。
 
+已发布的 GitHub 站内社区更新：
+
+- https://github.com/mss-boot-io/mss-boot-docs/discussions/41
+
 ## 中文短推
 
 mss-boot 近期社区更新：

--- a/aigc/prompts/community-update-post-2026-06-14.zh-CN.md
+++ b/aigc/prompts/community-update-post-2026-06-14.zh-CN.md
@@ -1,0 +1,91 @@
+# mss-boot 社区更新推文草稿（2026-06-14）
+
+## 背景
+
+本轮社区更新基于 2026-06-10 至 2026-06-14 已合并 PR、release 与安全治理状态整理。
+
+可公开同步的事实：
+
+- `mss-boot` 后端已发布 `v0.7.4`。
+- `mss-boot-admin-antd` 已发布 `v0.7.1`。
+- `mss-boot-admin-antd` 当前 GitHub Dependabot alert 已清零。
+- `mss-boot-docs` 当前仅剩 1 个 low severity `elliptic` 告警，且上游暂无 patched version。
+- 社区贡献者 `12ain` / Rain 的两项修复已合并：
+  - `mss-boot-admin#396`：SQLite / MySQL migration 兼容性修复。
+  - `mss-boot-admin-antd#114`：online-session 抽屉 loading、i18n key、按钮文案优化。
+- `mss-boot` 近期补强了测试、CI、release workflow 幂等性与 golangci-lint 增量质量门禁。
+- `mss-boot-docs` 继续沉淀贡献指南、AI 记忆与社区治理记录。
+
+发布边界：
+
+- GitHub 站内内容可以继续按维护者授权节奏推进。
+- CSDN、知乎、X、LinkedIn、Reddit、掘金等外部平台发布前，需要维护者在操作当次确认平台与账号。
+
+## 中文短推
+
+mss-boot 近期社区更新：
+
+后端 `mss-boot v0.7.4` 与前端 `mss-boot-admin-antd v0.7.1` 已发布。本轮重点推进可用性、兼容性和开源治理：admin-antd 安全告警已清零；docs 告警收敛到仅剩 1 个 low；后端补强测试、CI、release 幂等和 lint 质量门禁。
+
+感谢社区贡献者 `@12ain` / Rain：SQLite/MySQL migration 兼容修复、online-session 抽屉 loading、i18n key 与按钮文案优化已经合并。
+
+接下来欢迎参与 review：SQL migration/rollback、前端体验细节、docs/toolchain 安全治理。
+
+GitHub: https://github.com/mss-boot-io
+
+## 中文长帖
+
+mss-boot 近期社区更新：
+
+这轮主要把项目的可用性、兼容性、安全治理和开源协作往前推进了一步。
+
+1. 后端 `mss-boot v0.7.4` 已发布  
+   近期重点补强了测试覆盖、CI 稳定性、release workflow 幂等性，以及 golangci-lint 增量质量门禁。目标是让后续贡献者提交 PR 时，问题尽早在流水线里暴露，而不是靠人工反复兜底。
+
+2. 前端 `mss-boot-admin-antd v0.7.1` 已发布  
+   本轮修复了 stale token 导致白屏、独立部署首屏渲染等问题。当前 `mss-boot-admin-antd` 的 GitHub Dependabot alert 已清零，前端安全治理进入更可控的状态。
+
+3. docs 工程治理继续收敛  
+   `mss-boot-docs` 的安全告警已经收敛到仅剩 1 个 low severity `elliptic` 告警，且上游暂无 patched version。docs 仓库也继续沉淀贡献指南、AI 记忆、社区治理记录，保证项目协作过程可追溯。
+
+4. 感谢社区贡献者  
+   感谢 `@12ain` / Rain 提交并推动两项修复合并：
+   - `mss-boot-admin#396`：修复 SQLite / MySQL migration 兼容性问题。
+   - `mss-boot-admin-antd#114`：优化 online-session 抽屉 loading、i18n key 与按钮文案。
+
+接下来欢迎大家重点参与 review 和反馈：
+
+- SQL migration / rollback 设计。
+- admin 前端体验细节。
+- docs/toolchain 安全治理。
+- 新贡献者上手文档。
+
+项目地址：https://github.com/mss-boot-io
+
+## English Version
+
+mss-boot community update:
+
+We shipped `mss-boot v0.7.4` and `mss-boot-admin-antd v0.7.1`.
+
+This round focused on stability, compatibility, security governance, and open-source collaboration:
+
+- Backend CI, tests, idempotent release workflow, and golangci-lint gates were improved.
+- `mss-boot-admin-antd` fixed stale-token blank screen and standalone first paint issues.
+- `mss-boot-admin-antd` now has zero open Dependabot alerts.
+- `mss-boot-docs` is down to one low-severity `elliptic` alert with no upstream patched version available yet.
+- Community fixes from `@12ain` / Rain were merged:
+  - SQLite/MySQL migration compatibility in `mss-boot-admin#396`.
+  - online-session drawer loading, i18n key, and button text improvements in `mss-boot-admin-antd#114`.
+
+We welcome reviews and feedback on SQL migration/rollback design, admin frontend UX, docs/toolchain security, and contributor onboarding.
+
+GitHub: https://github.com/mss-boot-io
+
+## Link References
+
+- https://github.com/mss-boot-io/mss-boot/releases/tag/v0.7.4
+- https://github.com/mss-boot-io/mss-boot-admin-antd/releases/tag/v0.7.1
+- https://github.com/mss-boot-io/mss-boot-admin/pull/396
+- https://github.com/mss-boot-io/mss-boot-admin-antd/pull/114
+- https://github.com/mss-boot-io/mss-boot-docs/pull/35

--- a/aigc/prompts/community-update-post-2026-06-14.zh-CN.md
+++ b/aigc/prompts/community-update-post-2026-06-14.zh-CN.md
@@ -24,6 +24,74 @@
 已发布的 GitHub 站内社区更新：
 
 - https://github.com/mss-boot-io/mss-boot-docs/discussions/41
+- https://github.com/mss-boot-io/mss-boot-docs/discussions/42
+- https://github.com/mss-boot-io/mss-boot-docs/discussions/43
+
+外部平台执行状态：
+
+- 本轮已获得维护者“发布几篇推文到国内外社区”的当次授权。
+- Chrome 可运行，但 Codex Chrome Extension 未安装在插件当前选中的 `Default` profile；扩展安装在 `Profile 6`。
+- 按 Chrome 插件安全规则，不能绕过扩展使用 AppleScript、系统脚本或其它方式代发外部平台内容。
+- 外部平台发布需要维护者将 Codex Chrome Extension 启用到当前选中 profile，或让插件选中已安装扩展且已登录外部平台的 profile。
+
+## 平台化发布稿
+
+### 国内短动态（知乎 / 掘金 / CSDN 动态）
+
+mss-boot 近期社区更新：
+
+后端 `mss-boot v0.7.4` 与前端 `mss-boot-admin-antd v0.7.1` 已发布。本轮重点推进可用性、兼容性和开源治理：admin-antd 安全告警已清零；docs 告警收敛到仅剩 1 个 low；后端补强测试、CI、release 幂等和 lint 质量门禁。
+
+感谢社区贡献者 `@12ain` / Rain：SQLite/MySQL migration 兼容修复、online-session 抽屉 loading、i18n key 与按钮文案优化已经合并。
+
+接下来欢迎参与 review：SQL migration/rollback、前端体验细节、docs/toolchain 安全治理。
+
+项目地址：https://github.com/mss-boot-io
+
+### 国内长帖标题
+
+mss-boot 社区更新：v0.7.4、admin-antd v0.7.1 与安全治理收敛
+
+### X / Twitter
+
+mss-boot update: `mss-boot v0.7.4` and `mss-boot-admin-antd v0.7.1` are out.
+
+This round improves CI, release idempotency, frontend stability, and security governance. Thanks `@12ain` / Rain for migration compatibility and online-session UX fixes.
+
+https://github.com/mss-boot-io
+
+### LinkedIn
+
+mss-boot community update:
+
+We shipped `mss-boot v0.7.4` and `mss-boot-admin-antd v0.7.1`.
+
+This round focused on stability, compatibility, and open-source governance: stronger backend CI and release workflows, frontend blank-screen/first-paint fixes, zero open Dependabot alerts in `mss-boot-admin-antd`, and continued docs/security convergence.
+
+Thanks to `@12ain` / Rain for the SQLite/MySQL migration compatibility fix and online-session UX improvements.
+
+We welcome reviews on SQL migration/rollback behavior, admin frontend UX, docs/toolchain security, and contributor onboarding.
+
+GitHub: https://github.com/mss-boot-io
+
+### Reddit / Hacker News 说明稿
+
+Title: mss-boot v0.7.4 and admin-antd v0.7.1: CI, security governance, and community fixes
+
+Body:
+
+mss-boot is an open-source backend/admin stack. We recently shipped `mss-boot v0.7.4` and `mss-boot-admin-antd v0.7.1`.
+
+The latest round focused on:
+
+- Backend CI, tests, release workflow idempotency, and lint gates.
+- Frontend fixes for stale-token blank screens and standalone first paint.
+- Security governance: zero open Dependabot alerts in `mss-boot-admin-antd`.
+- Community contributions: SQLite/MySQL migration compatibility and online-session UX fixes from `@12ain` / Rain.
+
+We are looking for feedback on SQL migration/rollback behavior, admin frontend UX, and contributor onboarding.
+
+GitHub: https://github.com/mss-boot-io
 
 ## 中文短推
 


### PR DESCRIPTION
## Summary
- Add a durable AIGC memory file for the 2026-06-14 community update.
- Include Chinese short/long posts, an English version, source links, and publishing boundaries.
- Record the published GitHub Discussion URL for traceability.

## Tests / Verification
- git diff --check

## Docs Impact
- Docs-only AIGC memory update under `aigc/prompts/`.

## Security Impact
- No runtime security impact. The post summarizes current Dependabot/security governance status only.

## Release Impact
- No package release is required. This is a community/docs update and does not change published application behavior.

## Notes
- External non-GitHub platforms still require action-time maintainer confirmation before publishing.